### PR TITLE
Bad reference to blockId

### DIFF
--- a/src/steamship/data/file.py
+++ b/src/steamship/data/file.py
@@ -499,7 +499,7 @@ class File:
         for block in blocks:
             item = IndexItem(
                 value=block.text,
-                externalId=block.blockId,
+                externalId=block.id,
                 externalType="block"
             )
             items.append(item)


### PR DESCRIPTION
`block.blockId` should be `block.id`