### PR TITLE
Fix imports in client

### DIFF
--- a/src/steamship/client/client.py
+++ b/src/steamship/client/client.py
@@ -4,12 +4,11 @@ from typing import List
 from steamship.base import Client, Response
 from steamship.client.tasks import Tasks
 from steamship.data import Block, Classifier, Corpus, File
-from steamship.data.embedding import EmbedAndSearchRequest, EmbedAndSearchResponse
+from steamship.data.embedding import EmbedAndSearchRequest, EmbedAndSearchResponse, EmbedRequest, EmbedResponse
 from steamship.data.embedding_index import EmbeddingIndex
-from steamship.data.parser import TokenMatcher, PhraseMatcher, DependencyMatcher
+from steamship.data.parser import TokenMatcher, PhraseMatcher, DependencyMatcher, ParseRequest, ParseResponse
 from steamship.data.space import Space
 from steamship.data.tagging import TagRequest, TagResponse
-from steamship.plugin import EmbedRequest, EmbedResponse, ParseRequest, ParseResponse
 
 __copyright__ = "Steamship"
 __license__ = "MIT"


### PR DESCRIPTION
@eob I think that these imports are incorrect? I was struggling to test my parser plugin and then realized that lambda was getting this error:

```
{"Type": "User", "message": "Unable to get handler function from lambda code: cannot import name 'EmbedRequest' from 'steamship.plugin' (/tmp/localstack/zipfile.f9d3a965/steamship/plugin/__init__.py)", "__type": "InternalFailure"}
```

I also ran some of the Python client tests to verify that this works, but some of them are failing for me still. However, the one that imports the client now passes, so I think this should work.