### PR TITLE
Remove Pandas from the Client

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -267,10 +267,5 @@ python_version = ".".join(map(str, sys.version_info[0:2]))
 intersphinx_mapping = {
     "sphinx": ("http://www.sphinx-doc.org/en/stable", None),
     "python": ("https://docs.python.org/" + python_version, None),
-    "matplotlib": ("https://matplotlib.org", None),
-    "numpy": ("https://docs.scipy.org/doc/numpy", None),
-    "sklearn": ("https://scikit-learn.org/stable", None),
-    "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     "pyscaffold": ("https://pyscaffold.org/en/stable", None),
 }

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -24,7 +24,6 @@ imagesize==1.3.0
 iniconfig==1.1.1
 isort==5.10.1
 packaging==21.3
-pandas==1.4.2
 platformdirs==2.4.1
 pluggy==1.0.0
 pre-commit==2.19.0

--- a/src/steamship/data/embeddings.py
+++ b/src/steamship/data/embeddings.py
@@ -456,7 +456,6 @@ class EmbeddingIndex:
         query: Union[str, List[str]],
         k: int = 1,
         include_metadata: bool = False,
-        pd=False,
         space_id: str = None,
         space_handle: str = None,
         space: Any = None,
@@ -478,16 +477,8 @@ class EmbeddingIndex:
             space=space,
         )
 
-        if pd is False:
-            return ret
+        return ret
 
-        # noinspection PyPackageRequirements
-        import pandas as pd  # type: ignore
-
-        return pd.DataFrame(
-            [(hit.score, hit.value) for hit in ret.data.hits],
-            columns=["Score", "Value"],
-        )
 
     @staticmethod
     def create(


### PR DESCRIPTION
It was in there just for a display hack (for demos within Jupyter Notebook) and Pandas doesn't play very well with M1 Macs + Virtualenv. 