### PR TITLE
SteamshipResponse.wait() throws on timeout

### DIFF
--- a/src/steamship/base/response.py
+++ b/src/steamship/base/response.py
@@ -58,6 +58,12 @@ class Response(GenericModel, Generic[T]):
             self.refresh()
             time.sleep(retry_delay_s)
 
+        # If the task did not complete within the timout, throw an error
+        if self.task.state not in (TaskState.succeeded, TaskState.failed):
+            raise SteamshipError(
+                message=f"Task {self.task.task_id} did not complete within requested timeout of {max_timeout_s}s"
+            )
+
     def refresh(self):
         if self.task is not None:
             req = TaskStatusRequest(taskId=self.task.task_id)

--- a/tests/steamship_tests/server/test_task_timeout.py
+++ b/tests/steamship_tests/server/test_task_timeout.py
@@ -14,6 +14,6 @@ def test_task_timeout():
         res = instance.tag(doc=test_doc)
         try:
             res.wait(max_timeout_s=0.01, retry_delay_s=0.01)
-            assert False  # The call to wait() should throw
+            raise AssertionError("The call to wait() should throw")
         except SteamshipError:
             pass

--- a/tests/steamship_tests/server/test_task_timeout.py
+++ b/tests/steamship_tests/server/test_task_timeout.py
@@ -1,0 +1,19 @@
+from steamship_tests import PLUGINS_PATH
+from steamship_tests.utils.deployables import deploy_plugin
+from steamship_tests.utils.fixtures import get_steamship_client
+
+from steamship.base.error import SteamshipError
+
+
+def test_task_timeout():
+    client = get_steamship_client()
+    parser_path = PLUGINS_PATH / "taggers" / "plugin_parser.py"
+    # TODO (enias): Use Enum for plugin type
+    with deploy_plugin(client, parser_path, "tagger") as (plugin, version, instance):
+        test_doc = "Hi there"
+        res = instance.tag(doc=test_doc)
+        try:
+            res.wait(max_timeout_s=0.01, retry_delay_s=0.01)
+            assert False  # The call to wait() should throw
+        except SteamshipError:
+            pass


### PR DESCRIPTION
Making wait() throw an exception if it times out without the task completing.  Previously it would just happily return, which led to odd behavior when trying to use .data.