### PR TITLE
Add serializer for exceptions for remote logging

### DIFF
--- a/src/steamship/app/lambda_handler.py
+++ b/src/steamship/app/lambda_handler.py
@@ -19,10 +19,12 @@ from steamship.utils.signed_urls import upload_to_signed_url
 
 
 def encode_exception(obj):
+    """When logging an exception ex: logging.exception(some_error), the exception must be turned into a string
+    so that it is accepted by elasticsearch"""
     if isinstance(obj, SteamshipError):
-        return obj.to_dict()
+        return json.dumps(obj.to_dict())
     if isinstance(obj, Exception):
-        return {"exception_class": type(obj).__name__, "args": obj.args}
+        return f"exception_class: {type(obj).__name__}, args: {obj.args}"
     return obj
 
 

--- a/src/steamship/app/lambda_handler.py
+++ b/src/steamship/app/lambda_handler.py
@@ -18,6 +18,14 @@ from steamship.data.space import SignedUrl
 from steamship.utils.signed_urls import upload_to_signed_url
 
 
+def encode_exception(obj):
+    if isinstance(obj, SteamshipError):
+        return obj.to_dict()
+    if isinstance(obj, Exception):
+        return {"exception_class": type(obj).__name__, "args": obj.args}
+    return obj
+
+
 def create_handler(app_cls: Type[App]):  # noqa: C901
     """Wrapper function for a Steamship app within an AWS Lambda function."""
 
@@ -145,6 +153,7 @@ def create_handler(app_cls: Type[App]):  # noqa: C901
                 host=logging_host,
                 port=logging_port,
                 nanosecond_precision=True,
+                msgpack_kwargs={"default": encode_exception},
             )
             formatter = FluentRecordFormatter(custom_format)
             logging_handler.setFormatter(formatter)

--- a/tests/steamship_tests/base/test_steamship_error_serializable.py
+++ b/tests/steamship_tests/base/test_steamship_error_serializable.py
@@ -9,7 +9,7 @@ def test_serialize_steamship_error():
     serialized = msgpack.packb(error, default=encode_exception)
     assert (
         serialized
-        == b"\x82\xafexception_class\xaeSteamshipError\xa4args\x91\xbbOh noes! An error happened!"
+        == b"\x85\xa7message\xbbOh noes! An error happened!\xafinternalMessage\xc0\xaasuggestion\xc0\xa4code\xc0\xa5error\xc0"
     )
 
 

--- a/tests/steamship_tests/base/test_steamship_error_serializable.py
+++ b/tests/steamship_tests/base/test_steamship_error_serializable.py
@@ -1,0 +1,32 @@
+import msgpack
+
+from steamship import SteamshipError
+from steamship.app.lambda_handler import encode_exception
+
+
+def test_serialize_steamship_error():
+    error = SteamshipError("Oh noes! An error happened!")
+    serialized = msgpack.packb(error, default=encode_exception)
+    assert (
+        serialized
+        == b"\x82\xafexception_class\xaeSteamshipError\xa4args\x91\xbbOh noes! An error happened!"
+    )
+
+
+def test_serialize_steamship_error_with_nested_error():
+    nested_error = AttributeError("A nested error!")
+    error = SteamshipError("Oh noes! An error happened!", error=nested_error)
+    serialized = msgpack.packb(error, default=encode_exception)
+    assert (
+        serialized
+        == b"\x85\xa7message\xbbOh noes! An error happened!\xafinternalMessage\xc0\xaasuggestion\xc0\xa4code\xc0\xa5error\xafA nested error!"
+    )
+
+
+def test_serialize_non_steamship_error():
+    error = AttributeError("An attribute error!")
+    serialized = msgpack.packb(error, default=encode_exception)
+    assert (
+        serialized
+        == b"\x82\xafexception_class\xaeAttributeError\xa4args\x91\xb3An attribute error!"
+    )

--- a/tests/steamship_tests/base/test_steamship_error_serializable.py
+++ b/tests/steamship_tests/base/test_steamship_error_serializable.py
@@ -9,7 +9,7 @@ def test_serialize_steamship_error():
     serialized = msgpack.packb(error, default=encode_exception)
     assert (
         serialized
-        == b"\x85\xa7message\xbbOh noes! An error happened!\xafinternalMessage\xc0\xaasuggestion\xc0\xa4code\xc0\xa5error\xc0"
+        == b'\xd9t{"message": "Oh noes! An error happened!", "internalMessage": null, "suggestion": null, "code": null, "error": null}'
     )
 
 
@@ -19,14 +19,11 @@ def test_serialize_steamship_error_with_nested_error():
     serialized = msgpack.packb(error, default=encode_exception)
     assert (
         serialized
-        == b"\x85\xa7message\xbbOh noes! An error happened!\xafinternalMessage\xc0\xaasuggestion\xc0\xa4code\xc0\xa5error\xafA nested error!"
+        == b'\xd9\x81{"message": "Oh noes! An error happened!", "internalMessage": null, "suggestion": null, "code": null, "error": "A nested error!"}'
     )
 
 
 def test_serialize_non_steamship_error():
     error = AttributeError("An attribute error!")
     serialized = msgpack.packb(error, default=encode_exception)
-    assert (
-        serialized
-        == b"\x82\xafexception_class\xaeAttributeError\xa4args\x91\xb3An attribute error!"
-    )
+    assert serialized == b"\xd9?exception_class: AttributeError, args: ('An attribute error!',)"


### PR DESCRIPTION
Currently in elastic logs for python client we sometimes see CRITICAL - can't output to log.  This is because we sometimes call logging with an exception directly, ex:

```
 error = SteamshipError("Something is amiss!")
 logging.error(error)
```

The 'cant output to log' is because the SteamshipError is not msgpack serializable.  This PR makes SteamshipError msgpack serializable with its to_dict method, and makes any other exception serializable with its args.