### PR TITLE
Error to warning in client

### DIFF
--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -454,7 +454,7 @@ class Client(CamelModel, ABC):
             data = response_data
 
         if error is not None:
-            logging.error(f"Client received error from server: {error}", exc_info=error)
+            logging.warning(f"Client received error from server: {error}", exc_info=error)
             raise error
 
         elif task is not None:

--- a/src/steamship/data/file.py
+++ b/src/steamship/data/file.py
@@ -207,7 +207,7 @@ class File(CamelModel):
     def tag(
         self,
         plugin_instance: str = None,
-    ) -> Task[Tag]:
+    ) -> Task[Tag]:  # This actually is Task[TagResponse], right?
         # TODO (enias): Fix Circular imports
         from steamship.data.operations.tagger import TagRequest, TagResponse
         from steamship.data.plugin import PluginTargetType

--- a/src/steamship/data/plugin_instance.py
+++ b/src/steamship/data/plugin_instance.py
@@ -113,7 +113,7 @@ class PluginInstance(CamelModel):
         req = DeleteRequest(id=self.id)
         return self.client.post("plugin/instance/delete", payload=req, expect=PluginInstance)
 
-    def train(self, training_request: TrainingParameterPluginInput) -> TrainPluginOutput:
+    def train(self, training_request: TrainingParameterPluginInput) -> Task[TrainPluginOutput]:
         return self.client.post(
             "plugin/instance/train",
             payload=training_request,


### PR DESCRIPTION
This PR changes another location where a server-side error is logged as an error within the Python SDK.  Unfortunately, this means that any call to get on an object that doesn't exist is logged as error, even if expected.  Changing this to warning here cleans up the logs - if it's really error, it can be logged as such engine side.

Depends on #189 