### PR TITLE
Add a `list` method to the KVStore class.

### DIFF
--- a/src/steamship/utils/kv_store.py
+++ b/src/steamship/utils/kv_store.py
@@ -92,7 +92,7 @@ class KeyValueStore:
         req = Tag.CreateRequest(file_id=file.id, kind=self.store_identifier, name=key, value=value)
         return self.client.post("tag/create", req, expect=Tag)
 
-    def list(self, filter_keys: Optional[List[str]] = None) -> List[Tuple[str, Dict[str, Any]]]:
+    def items(self, filter_keys: Optional[List[str]] = None) -> List[Tuple[str, Dict[str, Any]]]:
         """Return all key-value entries as a list of (key, value) tuples.
 
         If `filter_keys` is provided, only returns keys within that list."""

--- a/tests/steamship_tests/utils/test_kv_store.py
+++ b/tests/steamship_tests/utils/test_kv_store.py
@@ -46,13 +46,13 @@ def test_key_value_store(client: Steamship):
     assert kv.get(key2) != value
 
     # List all the keys
-    res = kv.list()
+    res = kv.items()
     assert len(res) == 2
     assert (key1, value) in res
     assert (key2, value_2) in res
 
     # List just the keys with val1
-    res = kv.list(filter_keys=[key1])
+    res = kv.items(filter_keys=[key1])
     assert len(res) == 1
     assert (key1, value) in res
     assert (key2, value_2) not in res
@@ -64,7 +64,7 @@ def test_key_value_store(client: Steamship):
     got_3 = kv.get(key2)
 
     # List just the keys with val1
-    res = kv.list(filter_keys=[key2])
+    res = kv.items(filter_keys=[key2])
     assert len(res) == 1
     assert (key1, value) not in res
     assert (key2, value_3) in res

--- a/tests/steamship_tests/utils/test_kv_store.py
+++ b/tests/steamship_tests/utils/test_kv_store.py
@@ -44,11 +44,29 @@ def test_key_value_store():
     assert kv.get(key2) == value_2
     assert kv.get(key2) != value
 
+    # List all the keys
+    res = kv.list()
+    assert len(res) == 2
+    assert (key1, value) in res
+    assert (key2, value_2) in res
+
+    # List just the keys with val1
+    res = kv.list(filter_keys=[key1])
+    assert len(res) == 1
+    assert (key1, value) in res
+    assert (key2, value_2) not in res
+
     # Overwite the new one
     kv.set(key2, value_3)
     got = kv.get(key2)
     got_2 = kv.get(key2)
     got_3 = kv.get(key2)
+
+    # List just the keys with val1
+    res = kv.list(filter_keys=[key2])
+    assert len(res) == 1
+    assert (key1, value) not in res
+    assert (key2, value_3) in res
 
     assert got == value_3
     assert got != value_2


### PR DESCRIPTION
Was goofing off in the package layer and found utility in this:

- The more people build real things in packages, the more they'll need the ability to store app data
- This is a small change that adds a way to treat the KV store as a list of KV Pairs that you can set; e.g. dynamic user settings for the package or some external app that's using Steamship as a data store.