### PR TITLE
Support Python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.28.1
 pydantic==1.10.2
-aiohttp==3.8.1
+aiohttp==3.8.3
 inflection==0.5.1
 fluent-logger==0.10.0
 toml==0.10.2


### PR DESCRIPTION
aiohttp==3.8.1 didn't support python 3.11. 3.8.2 and 3.8.3 do. 
