### PR TITLE
[SHIP-461] Refresh updates self object (no need to reassign to variable)

### DIFF
--- a/src/steamship/data/file.py
+++ b/src/steamship/data/file.py
@@ -180,6 +180,7 @@ class File(CamelModel):
     def refresh(self) -> File:
         refreshed = File.get(self.client, self.id)
         self.__init__(**refreshed.dict())
+        self.client = refreshed.client
         return self
 
     @staticmethod

--- a/src/steamship/data/file.py
+++ b/src/steamship/data/file.py
@@ -178,7 +178,9 @@ class File(CamelModel):
         return client.post("file/create", payload=req, expect=File, as_background_task=True)
 
     def refresh(self) -> File:
-        return File.get(self.client, self.id)
+        refreshed = File.get(self.client, self.id)
+        self.__init__(**refreshed.dict())
+        return self
 
     @staticmethod
     def query(

--- a/tests/assets/plugins/importers/plugin_file_importer.py
+++ b/tests/assets/plugins/importers/plugin_file_importer.py
@@ -1,5 +1,5 @@
 from steamship import MimeTypes
-from steamship.invocable import Config, InvocableResponse, create_handler
+from steamship.invocable import InvocableResponse, create_handler
 from steamship.invocable.plugin_service import PluginRequest
 from steamship.plugin.file_importer import FileImporter
 from steamship.plugin.inputs.file_import_plugin_input import FileImportPluginInput
@@ -15,7 +15,6 @@ TEST_DOC = f"# {TEST_H1}\n\n{TEST_S1} {TEST_S2}\n\n{TEST_S3}\n"
 
 
 class TestFileImporterPlugin(FileImporter):
-
     def run(
         self, request: PluginRequest[FileImportPluginInput]
     ) -> InvocableResponse[RawDataPluginOutput]:

--- a/tests/assets/plugins/importers/plugin_file_importer_by_url.py
+++ b/tests/assets/plugins/importers/plugin_file_importer_by_url.py
@@ -1,5 +1,5 @@
 from steamship import MimeTypes
-from steamship.invocable import Config, InvocableResponse, create_handler
+from steamship.invocable import InvocableResponse, create_handler
 from steamship.invocable.plugin_service import PluginRequest
 from steamship.plugin.file_importer import FileImporter
 from steamship.plugin.inputs.file_import_plugin_input import FileImportPluginInput
@@ -15,7 +15,6 @@ TEST_DOC = f"# {TEST_H1}\n\n{TEST_S1} {TEST_S2}\n\n{TEST_S3}\n"
 
 
 class TestFileImporterPlugin(FileImporter):
-
     def run(
         self, request: PluginRequest[FileImportPluginInput]
     ) -> InvocableResponse[RawDataPluginOutput]:

--- a/tests/assets/plugins/importers/plugin_file_importer_python_error.py
+++ b/tests/assets/plugins/importers/plugin_file_importer_python_error.py
@@ -1,4 +1,4 @@
-from steamship.invocable import Config, InvocableResponse, create_handler
+from steamship.invocable import InvocableResponse, create_handler
 from steamship.invocable.plugin_service import PluginRequest
 from steamship.plugin.file_importer import FileImporter
 from steamship.plugin.inputs.file_import_plugin_input import FileImportPluginInput
@@ -6,7 +6,6 @@ from steamship.plugin.outputs.raw_data_plugin_output import RawDataPluginOutput
 
 
 class TestFileImporterPythonErrorPlugin(FileImporter):
-
     def run(
         self, request: PluginRequest[FileImportPluginInput]
     ) -> InvocableResponse[RawDataPluginOutput]:

--- a/tests/assets/plugins/taggers/plugin_embedder.py
+++ b/tests/assets/plugins/taggers/plugin_embedder.py
@@ -2,7 +2,7 @@ from typing import List
 
 from steamship import Block, File, Tag
 from steamship.data import TagKind, TagValue
-from steamship.invocable import Config, InvocableResponse, create_handler
+from steamship.invocable import InvocableResponse, create_handler
 from steamship.invocable.plugin_service import PluginRequest
 from steamship.plugin.embedder import Embedder
 from steamship.plugin.inputs.block_and_tag_plugin_input import BlockAndTagPluginInput
@@ -93,7 +93,6 @@ def _embed_block(block: Block) -> Block.CreateRequest:
 
 
 class TestEmbedderPlugin(Embedder):
-
     def run(
         self, request: PluginRequest[BlockAndTagPluginInput]
     ) -> InvocableResponse[BlockAndTagPluginOutput]:

--- a/tests/assets/plugins/taggers/plugin_logging_tagger.py
+++ b/tests/assets/plugins/taggers/plugin_logging_tagger.py
@@ -1,6 +1,6 @@
 import logging
 
-from steamship.invocable import Config, InvocableResponse, create_handler
+from steamship.invocable import InvocableResponse, create_handler
 from steamship.invocable.plugin_service import PluginRequest
 from steamship.plugin.inputs.block_and_tag_plugin_input import BlockAndTagPluginInput
 from steamship.plugin.outputs.block_and_tag_plugin_output import BlockAndTagPluginOutput
@@ -8,7 +8,6 @@ from steamship.plugin.tagger import Tagger
 
 
 class TestLoggingTaggerPlugin(Tagger):
-
     def run(
         self, request: PluginRequest[BlockAndTagPluginInput]
     ) -> InvocableResponse[BlockAndTagPluginOutput]:

--- a/tests/assets/plugins/taggers/plugin_parser.py
+++ b/tests/assets/plugins/taggers/plugin_parser.py
@@ -3,7 +3,7 @@ import re
 
 from steamship import Block, DocTag, Tag
 from steamship.data import TagKind
-from steamship.invocable import Config, InvocableResponse, create_handler
+from steamship.invocable import InvocableResponse, create_handler
 from steamship.invocable.plugin_service import PluginRequest
 from steamship.plugin.inputs.block_and_tag_plugin_input import BlockAndTagPluginInput
 from steamship.plugin.outputs.block_and_tag_plugin_output import BlockAndTagPluginOutput

--- a/tests/assets/plugins/taggers/plugin_third_party_trainable_tagger.py
+++ b/tests/assets/plugins/taggers/plugin_third_party_trainable_tagger.py
@@ -21,7 +21,7 @@ from assets.plugins.taggers.plugin_trainable_tagger import (
 
 from steamship import Block, File, SteamshipError, Tag
 from steamship.base import Task, TaskState
-from steamship.invocable import Config, InvocableResponse, create_handler
+from steamship.invocable import InvocableResponse, create_handler
 from steamship.plugin.inputs.block_and_tag_plugin_input import BlockAndTagPluginInput
 from steamship.plugin.inputs.train_plugin_input import TrainPluginInput
 from steamship.plugin.inputs.training_parameter_plugin_input import TrainingParameterPluginInput

--- a/tests/steamship_tests/plugin/unit/test_service.py
+++ b/tests/steamship_tests/plugin/unit/test_service.py
@@ -15,7 +15,6 @@ from steamship.plugin.trainable_model import TrainableModel
 
 
 class ValidStringToStringPlugin(PluginService):
-
     def run(self, request: PluginRequest[str]) -> Union[str, InvocableResponse[str]]:
         pass
 

--- a/tests/steamship_tests/utils/client.py
+++ b/tests/steamship_tests/utils/client.py
@@ -16,17 +16,19 @@ def get_steamship_client(fail_if_workspace_exists=False, **kwargs) -> Steamship:
 
 @contextmanager
 def steamship_use(
-        package_handle: str,
-        instance_handle: str = None,
-        config: Dict[str, Any] = None,
-        version: str = None,
-        fetch_if_exists: bool = True,
-        delete_workspace: bool = True,
-        **kwargs
+    package_handle: str,
+    instance_handle: str = None,
+    config: Dict[str, Any] = None,
+    version: str = None,
+    fetch_if_exists: bool = True,
+    delete_workspace: bool = True,
+    **kwargs
 ) -> PackageInstance:
     # Always use the `test` profile
     kwargs["profile"] = "test"
-    instance = Steamship.use(package_handle, instance_handle, config, version, fetch_if_exists, **kwargs)
+    instance = Steamship.use(
+        package_handle, instance_handle, config, version, fetch_if_exists, **kwargs
+    )
     assert instance.client.config.workspace_id == instance.workspace_id
     yield instance
     # Clean up the workspace
@@ -36,13 +38,13 @@ def steamship_use(
 
 @contextmanager
 def steamship_use_plugin(
-        plugin_handle: str,
-        instance_handle: str = None,
-        config: Dict[str, Any] = None,
-        version: str = None,
-        fetch_if_exists: bool = True,
-        delete_workspace: bool = True,
-        **kwargs
+    plugin_handle: str,
+    instance_handle: str = None,
+    config: Dict[str, Any] = None,
+    version: str = None,
+    fetch_if_exists: bool = True,
+    delete_workspace: bool = True,
+    **kwargs
 ) -> PluginInstance:
     # Always use the `test` profile
     kwargs["profile"] = "test"

--- a/tests/steamship_tests/utils/client.py
+++ b/tests/steamship_tests/utils/client.py
@@ -5,10 +5,12 @@ from steamship import Configuration, Steamship
 from steamship.data.package.package_instance import PackageInstance
 from steamship.data.plugin.plugin_instance import PluginInstance
 
+TESTING_PROFILE = "test"
+
 
 def get_steamship_client(fail_if_workspace_exists=False, **kwargs) -> Steamship:
     # Always use the `test` profile
-    kwargs["profile"] = "test"
+    kwargs["profile"] = TESTING_PROFILE
     return Steamship(
         fail_if_workspace_exists=fail_if_workspace_exists, config=Configuration.parse_obj(kwargs)
     )
@@ -25,7 +27,7 @@ def steamship_use(
     **kwargs
 ) -> PackageInstance:
     # Always use the `test` profile
-    kwargs["profile"] = "test"
+    kwargs["profile"] = TESTING_PROFILE
     instance = Steamship.use(
         package_handle, instance_handle, config, version, fetch_if_exists, **kwargs
     )
@@ -47,7 +49,7 @@ def steamship_use_plugin(
     **kwargs
 ) -> PluginInstance:
     # Always use the `test` profile
-    kwargs["profile"] = "test"
+    kwargs["profile"] = TESTING_PROFILE
     instance = Steamship.use_plugin(
         plugin_handle, instance_handle, config, version, fetch_if_exists, **kwargs
     )


### PR DESCRIPTION
Note - most of the changed lines in this PR are just making black and pycln happy again - somehow we got into a state where the files unmodified by this PR did not meet their standards.  I wanted these fixed so that we could see the green check again.