### PR TITLE
Add a text field to `Tag`

### DIFF
--- a/src/steamship/data/tags/tag.py
+++ b/src/steamship/data/tags/tag.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from pydantic import Field
 
@@ -15,17 +15,40 @@ class TagQueryRequest(Request):
 
 
 class Tag(CamelModel):
+    # Steamship client.
     client: Client = Field(None, exclude=True)
+
+    # ID of the tag in the database.
     id: str = None
+
+    # ID of the file associated with the tag.
     file_id: str = None
-    block_id: str = None
+
+    # ID of the block associated with the tag. If not None, `start_idx` and `end_idx` should be set.
+    block_id: Optional[str] = None
+
+    # The kind of tag. See the ``TagKind`` enum class for suggestions.
     kind: str = None  # E.g. ner
-    name: str = None  # E.g. person
-    value: Dict[str, Any] = None  # JSON Metadata
-    start_idx: int = None  # w/r/t block.text. None means 0 if blockId is not None
-    end_idx: int = None  # w/r/t block.text. None means -1 if blockId is not None
+
+    # The name of tag. See the ``DocTag``, ``TokenTag``, etc enum classes for suggestions.
+    name: Optional[str] = None  # E.g. person
+
+    # The value payload of the tag. Always a JSON-style object.
+    value: Optional[Dict[str, Any]] = None
+
+    # Start-index of the text covered by the tag, using python slice semantics.
+    start_idx: Optional[int] = None
+
+    # End-index of the text covered by the tag, using python slice semantics.
+    end_idx: Optional[int] = None
+
+    # The text covered by the tag. Note that text will not always be materialized into the tag object
+    # itself; you may have to fetch it with file.text[tag.start_idx:tag.end_idx]
+    text: Optional[str] = None
 
     class CreateRequest(Request):
+        """Request to create a new Tag."""
+
         id: str = None
         file_id: str = None
         block_id: str = None

--- a/src/steamship/data/tags/tag.py
+++ b/src/steamship/data/tags/tag.py
@@ -36,14 +36,20 @@ class Tag(CamelModel):
     # The value payload of the tag. Always a JSON-style object.
     value: Optional[Dict[str, Any]] = None
 
-    # Start-index of the text covered by the tag, using python slice semantics.
+    # Character index in associated block of the start of the span of text this tag comments upon. Start-inclusive.
     start_idx: Optional[int] = None
 
-    # End-index of the text covered by the tag, using python slice semantics.
+    # Character index in associated block of the end of the span of text this tag comments upon. End-exclusive.
     end_idx: Optional[int] = None
 
-    # The text covered by the tag. Note that text will not always be materialized into the tag object
-    # itself; you may have to fetch it with file.text[tag.start_idx:tag.end_idx]
+    # The text covered by the tag.
+    # Note:
+    #   The text will not always be materialized into the tag object
+    #   itself; you may have to fetch it with file.text[tag.start_idx:tag.end_idx]
+    # Note:
+    #   Changing this field will not result in changes to Steamship's database.
+    #   TODO(ted): Consider refactoring as a read-only property.
+    #
     text: Optional[str] = None
 
     class CreateRequest(Request):


### PR DESCRIPTION
I'm going to try splitting up the embedding refactor into several smaller commits.

All of our conversations around design involved the `Tag` field gaining a `text` field so that it could be stored/retreived/worked-with as an atomic object separate from the file from which it came.

This PR adds that field.