### PR TITLE
Add a `config` object on method registration, to be returned in __dir__

### DIFF
--- a/src/steamship/base/package_spec.py
+++ b/src/steamship/base/package_spec.py
@@ -1,6 +1,6 @@
 """Objects for recording and reporting upon the introspected interface of a Steamship Package."""
 import inspect
-from typing import List, Optional
+from typing import Dict, List, Optional, Union
 
 from steamship import SteamshipError
 from steamship.base.configuration import CamelModel
@@ -47,6 +47,9 @@ class MethodSpec(CamelModel):
     # The named arguments of the method. Positional arguments are not permitted.
     args: Optional[List[ArgSpec]] = None
 
+    # Additional configuration around this endpoint.
+    config: Optional[Dict[str, Union[str, bool, int, float]]] = None
+
     @staticmethod
     def clean_path(path: str = "") -> str:
         """Ensure that the path always starts with /, and at minimum must be at least /."""
@@ -56,7 +59,14 @@ class MethodSpec(CamelModel):
             path = f"/{path}"
         return path
 
-    def __init__(self, cls: object, name: str, path: str = None, verb: Verb = Verb.POST):
+    def __init__(
+        self,
+        cls: object,
+        name: str,
+        path: str = None,
+        verb: Verb = Verb.POST,
+        config: Dict[str, Union[str, bool, int, float]] = None,
+    ):
         # Set the path
         if path is None and name is not None:
             path = f"/{name}"
@@ -79,7 +89,7 @@ class MethodSpec(CamelModel):
                 continue
             args.append(ArgSpec(p, sig.parameters[p]))
 
-        super().__init__(path=path, verb=verb, returns=returns, doc=doc, args=args)
+        super().__init__(path=path, verb=verb, returns=returns, doc=doc, args=args, config=config)
 
     def pprint(self, name_width: Optional[int] = None, prefix: str = "  ") -> str:
         """Returns a pretty printable representation of this method."""

--- a/src/steamship/base/package_spec.py
+++ b/src/steamship/base/package_spec.py
@@ -48,7 +48,9 @@ class MethodSpec(CamelModel):
     args: Optional[List[ArgSpec]] = None
 
     # Additional configuration around this endpoint.
-    config: Optional[Dict[str, Union[str, bool, int, float]]] = None
+    # Note: The actual type of this is Optional[Dict[str, Union[str, bool, int, float]]]
+    #       But if Pydantic sees that, it attempts to force all values to be str, which is wrong.
+    config: Optional[Dict] = None
 
     @staticmethod
     def clean_path(path: str = "") -> str:

--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -62,14 +62,8 @@ def endpoint(verb: str = None, path: str = None, **kwargs):
         # Build a dictionary of String->Primitive Types to pass back with endpoint
         # This enables the Engine to add support for features like public=True, etc, without the Client changing.
         config: Dict[str, Union[str, bool, int, float]] = {}
-        for key in kwargs:
-            val = kwargs[key]
-            if (
-                isinstance(val, str)
-                or isinstance(val, bool)
-                or isinstance(val, int)
-                or isinstance(val, float)
-            ):
+        for key, val in kwargs.items():
+            if isinstance(val, (str, bool, int, float)):
                 config[key] = val
 
         wrap.__path__ = path

--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -7,7 +7,7 @@ from abc import ABC
 from collections import defaultdict
 from functools import wraps
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type, Union
 
 import toml
 
@@ -43,7 +43,6 @@ def make_registering_decorator(decorator):
     new_decorator.__name__ = decorator.__name__
     new_decorator.__doc__ = decorator.__doc__
     new_decorator.__is_endpoint__ = True
-
     return new_decorator
 
 
@@ -60,8 +59,23 @@ def endpoint(verb: str = None, path: str = None, **kwargs):
         def wrap(self, *args, **kwargs):
             return function(self, *args, **kwargs)
 
+        # Build a dictionary of String->Primitive Types to pass back with endpoint
+        # This enables the Engine to add support for features like public=True, etc, without the Client changing.
+        config: Dict[str, Union[str, bool, int, float]] = {}
+        for key in kwargs:
+            val = kwargs[key]
+            if (
+                isinstance(val, str)
+                or isinstance(val, bool)
+                or isinstance(val, int)
+                or isinstance(val, float)
+            ):
+                config[key] = val
+
         wrap.__path__ = path
         wrap.__verb__ = verb
+        wrap.__endpoint_config__ = config
+
         return wrap
 
     decorator = make_registering_decorator(decorator)
@@ -139,8 +153,9 @@ class Invocable(ABC):
                 if getattr(decorator, "__is_endpoint__", False):
                     path = getattr(attribute, "__path__", None)
                     verb = getattr(attribute, "__verb__", None)
+                    config = getattr(attribute, "__endpoint_config__", {})
                     method_spec = cls._register_mapping(
-                        name=attribute.__name__, verb=verb, path=path
+                        name=attribute.__name__, verb=verb, path=path, config=config
                     )
                     cls._package_spec.methods.append(method_spec)
 
@@ -173,10 +188,14 @@ class Invocable(ABC):
 
     @classmethod
     def _register_mapping(
-        cls, name: str, verb: Optional[Verb] = None, path: str = ""
+        cls,
+        name: str,
+        verb: Optional[Verb] = None,
+        path: str = "",
+        config: Dict[str, Union[int, float, bool, str]] = None,
     ) -> MethodSpec:
         """Registering a mapping permits the method to be invoked via HTTP."""
-        method_spec = MethodSpec(cls, name, path=path, verb=verb)
+        method_spec = MethodSpec(cls, name, path=path, verb=verb, config=config)
         # It's important to use method_spec.path below since that's the CLEANED path.
         cls._method_mappings[verb][method_spec.path] = name
         # TODO Dave: this log call is not going to the remote logger, but should

--- a/tests/assets/demo_package_spec.json
+++ b/tests/assets/demo_package_spec.json
@@ -6,6 +6,7 @@
       "path": "/resp_string",
       "doc": null,
       "args": [],
+      "config": {},
       "returns": "<class 'l_22bcb053.InvocableResponse[str]'>",
       "verb": "GET"
     },
@@ -13,6 +14,7 @@
       "path": "/resp_dict",
       "doc": null,
       "args": [],
+      "config": {},
       "verb": "GET",
       "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>"
     },
@@ -20,6 +22,7 @@
       "path": "/resp_obj",
       "doc": null,
       "args": [],
+      "config": {},
       "verb": "GET",
       "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>"
     },
@@ -28,21 +31,24 @@
       "doc": null,
       "verb": "GET",
       "returns": "<class 'l_22bcb053.InvocableResponse[bytes]'>",
-      "args": []
+      "args": [],
+      "config": {}
     },
     {
       "path": "/resp_bytes_io",
       "doc": null,
       "verb": "GET",
       "returns": "<class 'l_22bcb053.InvocableResponse[bytes]'>",
-      "args": []
+      "args": [],
+      "config": {}
     },
     {
       "path": "/resp_image",
       "doc": null,
       "returns": "<class 'l_22bcb053.InvocableResponse[bytes]'>",
       "verb": "GET",
-      "args": []
+      "args": [],
+      "config": {}
     },
     {
       "path": "/greet",
@@ -53,6 +59,12 @@
           "kind": "<class 'str'>"
         }
       ],
+      "config": {
+        "body": 98.6,
+        "identifier": "foo",
+        "public": true,
+        "timeout": 10
+      },
       "verb": "GET",
       "returns": "<class 'l_22bcb053.InvocableResponse[str]'>"
     },
@@ -66,6 +78,7 @@
           "name": "name"
         }
       ],
+      "config": {},
       "verb": "POST"
     },
     {
@@ -73,6 +86,7 @@
       "doc": null,
       "returns": "<class 'l_22bcb053.InvocableResponse[str]'>",
       "args": [],
+      "config": {},
       "verb": "GET"
     },
     {
@@ -80,6 +94,7 @@
       "doc": null,
       "verb": "POST",
       "args": [],
+      "config": {},
       "returns": "<class 'l_22bcb053.InvocableResponse[str]'>"
     },
     {
@@ -87,6 +102,7 @@
       "doc": null,
       "verb": "POST",
       "returns": "<class 'l_22bcb053.InvocableResponse[str]'>",
+      "config": {},
       "args": []
     },
     {
@@ -94,6 +110,7 @@
       "doc": null,
       "verb": "POST",
       "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>",
+      "config": {},
       "args": []
     },
     {
@@ -101,11 +118,13 @@
       "doc": "Our base client tries to be smart with parsing things that look like SteamshipResponse objects, but there's\n        a problem with this when our packages response with a JSON string of the sort {\"status\": \"foo\"} -- the Client\n        will unhelpfully try to coerce that string value into a Task object and fail. This method helps us test that\n        we are handling it properly.",
       "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>",
       "verb": "POST",
+      "config": {},
       "args": []
     },
     {
       "path": "/config",
       "doc": "This is called get_config because there's already `.config` object on the class.",
+      "config": {},
       "args": [],
       "verb": "GET",
       "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>"
@@ -114,6 +133,7 @@
       "path": "/learn",
       "doc": "Learns a new fact.",
       "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>",
+      "config": {},
       "args": [
         {
           "name": "fact",
@@ -126,6 +146,7 @@
       "path": "/query",
       "doc": "Learns a new fact.",
       "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>",
+      "config": {},
       "args": [
         {
           "name": "query",

--- a/tests/assets/packages/demo_package.py
+++ b/tests/assets/packages/demo_package.py
@@ -51,7 +51,9 @@ class TestPackage(PackageService):
         _bytes = base64.b64decode(PALM_TREE_BASE_64)
         return InvocableResponse(_bytes=_bytes, mime_type=MimeTypes.PNG)
 
-    @get("greet")
+    @get(
+        "greet", public=True, timeout=10, identifier="foo", body=98.6, not_there={"not": "included"}
+    )
     def greet1(self, name: str = "Person") -> InvocableResponse[str]:
         return InvocableResponse(string=f"Hello, {name}!")
 

--- a/tests/steamship_tests/app/unit/test_demo_app_spec.py
+++ b/tests/steamship_tests/app/unit/test_demo_app_spec.py
@@ -1,4 +1,3 @@
-import pprint
 from typing import Callable, Optional
 
 import pytest
@@ -8,7 +7,25 @@ from assets.packages.demo_package import TestPackage
 @pytest.mark.parametrize("invocable_handler", [TestPackage], indirect=True)
 def test_package_spec(invocable_handler: Callable[[str, str, Optional[dict]], dict]):
     """Test that the handler returns the proper directory information"""
-    response_dict = invocable_handler("GET", "/__dir__", {})
-    pp = pprint.PrettyPrinter(indent=4)
-    print()
-    pp.pprint(response_dict)
+    rd = invocable_handler("GET", "/__dir__", {}).get("data")
+
+    assert rd.get("doc") is None
+    assert rd.get("methods") is not None
+    assert len(rd.get("methods")) == 16
+
+    saw_public = False
+
+    for method in rd.get("methods"):
+        if method.get("path") == "/greet" and method.get("verb") == "GET":
+            assert method.get("config") is not None
+            assert method.get("config").get("public") is True
+            assert method.get("config").get("timeout") == 10
+            assert method.get("config").get("identifier") == "foo"
+            assert method.get("config").get("body") == 98.6
+            assert method.get("config").get("not_there") is None
+
+            saw_public = True
+        else:
+            assert method.get("config") == {}
+
+    assert saw_public


### PR DESCRIPTION
There's value in exploring the possibility of "public" package endpoints:

* Certain operations, like web hooks, are not configurable with an `Authentication` header. The Telegram bot api is an example of this.
* Hosting a simple web UI from within a package 
* Hosting an endpoint that a web form or other unauth'ed user could post to

One way to support this would be via an annotation, such as:

```
@post("/add-data", public=True)
def add_data(self..)
```

This PR transforms all primitive-valued kwargs after the `path` in the @get and @post comments into a `config` object which is returned in the __dir__ object.

This permits us to experiment with support for things like public endpoints without having to fiddle with custom client versions; we just put it in the kwargs and have the engine react to it once the AppVersion is deployed.

