### PR TITLE
Fix two bugs: File.create when both `content` and `tags` are present, and multipart Mime-posting of nested objects

### DIFF
--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -5,7 +5,7 @@ import logging
 import typing
 from abc import ABC
 from inspect import isclass
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, List, Type, TypeVar, Union
 
 import inflection
 from pydantic import BaseModel, PrivateAttr
@@ -293,10 +293,12 @@ class Client(CamelModel, ABC):
         result = {}
         for key, val in data.items():
             if val:
-                if isinstance(val, Dict):
+                if isinstance(val, dict):
+                    result[key] = (None, json.dumps(val), "application/json")
+                elif isinstance(val, list):
                     result[key] = (None, json.dumps(val), "application/json")
                 else:
-                    result[key] = (None, str(val))
+                    result[key] = (None, str(val), "application/json")
         result["file"] = file
         return result
 

--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import json
 import logging
 import typing
 from abc import ABC
 from inspect import isclass
-from typing import Any, List, Type, TypeVar, Union
+from typing import Any, List, Optional, Tuple, Type, TypeVar, Union
 
 import inflection
 from pydantic import BaseModel, PrivateAttr
@@ -22,6 +21,31 @@ from steamship.utils.url import Verb, is_local
 _logger = logging.getLogger(__name__)
 
 T = TypeVar("T")  # TODO (enias): Do we need this?
+
+
+def _multipart_name(path: str, val: Any) -> List[Tuple[Optional[str], str, Optional[str]]]:
+    """Decode any object into a series of HTTP Multi-part segments that Vapor will consume.
+
+    https://github.com/vapor/multipart-kit
+    When sending a JSON object in a MultiPart request, Vapor wishes to see multi part segments as follows:
+
+    single_key
+    array_key[idx]
+    obj_key[prop]
+
+    So a File with a list of one tag with kind=Foo would be transmitted as setting the part:
+    [tags][0][kind]
+    """
+    ret = []
+    if isinstance(val, dict):
+        for key, subval in val.items():
+            ret.extend(_multipart_name(f"{path}[{key}]", subval))
+    elif isinstance(val, list):
+        for idx, subval in enumerate(val):
+            ret.extend(_multipart_name(f"{path}[{idx}]", subval))
+    elif val is not None:
+        ret.append((path, val, None))
+    return ret
 
 
 class Client(CamelModel, ABC):
@@ -292,13 +316,8 @@ class Client(CamelModel, ABC):
 
         result = {}
         for key, val in data.items():
-            if val:
-                if isinstance(val, dict):
-                    result[key] = (None, json.dumps(val), "application/json")
-                elif isinstance(val, list):
-                    result[key] = (None, json.dumps(val), "application/json")
-                else:
-                    result[key] = (None, str(val), "application/json")
+            for t in _multipart_name(key, val):
+                result[t[0]] = t
         result["file"] = file
         return result
 

--- a/src/steamship/data/file.py
+++ b/src/steamship/data/file.py
@@ -67,6 +67,7 @@ class File(CamelModel):
         data: str = None
         id: str = None
         url: str = None
+        handle: str = None
         filename: str = None
         type: FileUploadType = None
         mime_type: str = None
@@ -130,6 +131,7 @@ class File(CamelModel):
         client: Client,
         content: Union[str, bytes] = None,
         mime_type: str = None,
+        handle: str = None,
         blocks: List[Block.CreateRequest] = None,
         tags: List[Tag.CreateRequest] = None,
     ) -> File:
@@ -151,6 +153,7 @@ class File(CamelModel):
             raise Exception("Unable to determine upload type.")
 
         req = File.CreateRequest(
+            handle=handle,
             type=upload_type,
             mime_type=mime_type,
             blocks=blocks,

--- a/src/steamship/data/file.py
+++ b/src/steamship/data/file.py
@@ -136,10 +136,11 @@ class File(CamelModel):
         tags: List[Tag.CreateRequest] = None,
     ) -> File:
 
-        if content is None and blocks is None and tags is None:
-            raise SteamshipError(
-                message="Either filename, content, url, or plugin Instance must be provided."
-            )
+        if content is None and blocks is None:
+            if tags is None:
+                raise SteamshipError(message="Either filename, content, or tags must be provided.")
+            else:
+                content = ""
         if content is not None and blocks is not None:
             raise SteamshipError(
                 message="Please provide only `blocks` or `content` to `File.create`."

--- a/src/steamship/data/package/package_version.py
+++ b/src/steamship/data/package/package_version.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, Type
 
 from pydantic import BaseModel, Field
@@ -14,7 +15,8 @@ class CreatePackageVersionRequest(Request):
     handle: str = None
     type: str = "file"
     hosting_handler: str = None
-    config_template: Dict[str, Any] = None
+    # Note: this is a Dict[str, Any] but should be transmitted to the Engine as a JSON string
+    config_template: str = None
 
 
 class PackageVersion(CamelModel):
@@ -53,7 +55,7 @@ class PackageVersion(CamelModel):
         req = CreatePackageVersionRequest(
             handle=handle,
             package_id=package_id,
-            config_template=config_template,
+            config_template=json.dumps(config_template or {}),
             hosting_handler=hosting_handler,
         )
 

--- a/src/steamship/data/plugin/plugin_version.py
+++ b/src/steamship/data/plugin/plugin_version.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, List, Optional, Type
 
 from pydantic import BaseModel, Field
@@ -21,7 +22,8 @@ class CreatePluginVersionRequest(Request):
     is_public: bool = None
     is_default: bool = None
     type: str = "file"
-    config_template: Dict[str, Any] = None
+    # Note: this is a Dict[str, Any] but should be transmitted to the Engine as a JSON string
+    config_template: str = None
 
 
 class ListPluginVersionsRequest(Request):
@@ -83,7 +85,7 @@ class PluginVersion(CamelModel):
             hosting_handler=hosting_handler,
             is_public=is_public,
             is_default=is_default,
-            config_template=config_template,
+            config_template=json.dumps(config_template or {}),
         )
 
         task = client.post(

--- a/tests/steamship_tests/data/test_file.py
+++ b/tests/steamship_tests/data/test_file.py
@@ -13,9 +13,10 @@ from steamship.data.tags.tag import Tag
 
 @pytest.mark.usefixtures("client")
 def test_file_upload(client: Steamship):
-    a = File.create(client=client, content="A", mime_type=MimeTypes.MKD)
+    a = File.create(client=client, handle="foo", content="A", mime_type=MimeTypes.MKD)
     assert a.id is not None
     assert a.mime_type == MimeTypes.MKD
+    assert a.handle == "foo"
 
     b = File.create(client=client, content="B", mime_type=MimeTypes.TXT)
     assert b.id is not None


### PR DESCRIPTION
There are two ways to create a file:
* Provide Block JSON (blocks and tags)
* Provide content

There's a third way which should be supported:
* Provide content along with file-tags

But when `File.create` was called with both `content` and `tags`, the client would incorrectly set the upload type to BLOCK_JSON, which would result in an empty file (but one that contained tags).

## Change

This PR changes the behavior of File.create to make the upload type decision based only on the presence/absence of `blocks` or `content` --- not the `tags` property. 

This should allow for files to be created with `File.create(content=..., tags=...)`

## .. But then there's a new problem

Fixing this bug uncovers a new bug lurking in our multi-part POST handling. It's probably been there all along and we just never noticed.

When running the new test:

```
test_file::test_file_upload_with_content_and_tags
```

We get the following failure:

```
E           steamship.base.error.SteamshipError: [AbortError]
E           Value of type 'MultipartPart' required for key 'tags'.
```

Here's how we encode the file data:

```
            ("file-part", content, "multipart/form-data")
```

And here's how we encode the fields on the object:

```
                    result[key] = (None, json.dumps(val), "application/json")
```

What I suspect is happening is that the way we're encoding the POST causes:
- Swift to correctly understand the file bytes;
- Swift to correctly understand individual primitive types (bool, string, int) on the uploaded file. I added the `handle` parameter to File.CreateRequest and File.create to test & verify that primitive types worked in a multi-part request, and it appears they do.
- Swift to not understand complex types (tags, which is an array of Tag.CreateRequest encoded as JSON

This might be a Swift problem -- perhaps Vapor (swift web framework) doesn't handle unpacking multi-part requests well into a nested object.

# Update

The Mime problem is solved! Vapor just wants a very specific encoding.

cc @douglas-reid 