### PR TITLE
Adds an `invoke_later` method to invocables

### DIFF
--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -254,7 +254,7 @@ class Client(CamelModel, ABC):
         if wait_on_tasks:
             # Will result in the engine persisting the inbound HTTP request as a Task for deferred
             # execution. Additionally, the task will be scheduled to first wait on the other tasks
-            # provided in the list of IDs.
+            # provided in the list of IDs. Accepts a list of EITHER Task objects OR task_id strings.
             as_background_task = True
             task_ids = []
             for task_or_id in wait_on_tasks:

--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -264,7 +264,7 @@ class Client(CamelModel, ABC):
                     task_ids.append(task_or_id.task_id)
                 else:
                     raise SteamshipError(
-                        message=f"`wait_on_tasks` should only contain Task of str objects. Got a {type(task_or_id)}."
+                        message=f"`wait_on_tasks` should only contain Task or str objects. Got a {type(task_or_id)}."
                     )
 
             headers["X-Task-Dependency"] = ",".join(task_ids)

--- a/src/steamship/base/tasks.py
+++ b/src/steamship/base/tasks.py
@@ -241,6 +241,9 @@ class Task(GenericCamelModel, Generic[T]):
             )
 
     def refresh(self):
+        if self.task_id is None:
+            raise SteamshipError(message="Unable to refresh task because `task_id` is None")
+
         req = TaskStatusRequest(taskId=self.task_id)
         # TODO (enias): A status call can return both data and task
         # In this case both task and data will include the output (one is string serialized, the other is parsed)

--- a/src/steamship/base/tasks.py
+++ b/src/steamship/base/tasks.py
@@ -128,14 +128,17 @@ class TaskStatusRequest(Request):
 class Task(GenericCamelModel, Generic[T]):
     """Encapsulates a unit of asynchronously performed work."""
 
+    # Note: The Field object prevents this from being serialized into JSON (and causing a crash)
     client: Client = Field(None, exclude=True)  # Steamship client
 
     task_id: str = None  # The id of this task
     user_id: str = None  # The user who requested this task
     workspace_id: str = None  # The workspace in which this task is executing
+
+    # Note: The Field object prevents this from being serialized into JSON (and causing a crash)
     expect: Type = Field(
         None, exclude=True
-    )  # Type of the expected output once the output is complete
+    )  # Type of the expected output once the output is complete.
 
     input: str = None  # The input provided to the task
     output: T = None  # The output of the task

--- a/src/steamship/base/tasks.py
+++ b/src/steamship/base/tasks.py
@@ -133,7 +133,9 @@ class Task(GenericCamelModel, Generic[T]):
     task_id: str = None  # The id of this task
     user_id: str = None  # The user who requested this task
     workspace_id: str = None  # The workspace in which this task is executing
-    expect: Type = None  # Type of the expected output once the output is complete
+    expect: Type = Field(
+        None, exclude=True
+    )  # Type of the expected output once the output is complete
 
     input: str = None  # The input provided to the task
     output: T = None  # The output of the task

--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -200,7 +200,7 @@ class Invocable(ABC):
 
         :param method: The method to invoke, as registered with Steamship in the @get or @post decorator.
         :param verb: The HTTP Verb to use. Default is POST.
-        :param after_tasks: A list of Task objects (or task IDs) that should be waited upon before invocation.
+        :param wait_on_tasks: A list of Task objects (or task IDs) that should be waited upon before invocation.
         :param arguments: The keyword arguments of the invoked method
 
         :return: returns a Task representing the future work

--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -7,11 +7,10 @@ from abc import ABC
 from collections import defaultdict
 from functools import wraps
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, Optional, Type, Union
 
 import toml
 
-from steamship import SteamshipError, Task
 from steamship.base.package_spec import MethodSpec, PackageSpec
 from steamship.client import Steamship
 from steamship.invocable import Config
@@ -188,55 +187,6 @@ class Invocable(ABC):
                 return MyPackageOrPlugin.MyConfig
         """
         return Config
-
-    def invoke_later(
-        self,
-        method: str,
-        verb: Verb = Verb.POST,
-        wait_on_tasks: List[Union[Task, str]] = None,
-        arguments: Dict[str, Any] = None,
-    ) -> Task[Any]:
-        """Schedule a method for future invocation.
-
-        :param method: The method to invoke, as registered with Steamship in the @get or @post decorator.
-        :param verb: The HTTP Verb to use. Default is POST.
-        :param wait_on_tasks: A list of Task objects (or task IDs) that should be waited upon before invocation.
-        :param arguments: The keyword arguments of the invoked method
-
-        :return: returns a Task representing the future work
-        """
-
-        if self.context is None:
-            raise SteamshipError(
-                message="Unable to call invoke_later because the InvocationContext was None"
-            )
-        if self.context.invocable_instance_handle is None:
-            raise SteamshipError(
-                message="Unable to call invoke_later because the invocable_instance_handle on InvocationContext was None"
-            )
-
-        payload = {
-            "instanceHandle": self.context.invocable_instance_handle,
-            "payload": {
-                "httpVerb": verb.value,
-                "invocationPath": method,
-                "arguments": arguments or {},
-            },
-        }
-        operation = "package/instance/invoke"
-
-        logging.info(
-            f"Scheduling {verb} {method} for future invocation on me ({self.context.invocable_handle})"
-        )
-
-        resp = self.client.post(
-            operation,
-            payload,
-            expect=Task[Task],  # This operation should return a task
-            as_background_task=True,  # This operation should always be asynchronous
-            wait_on_tasks=wait_on_tasks,  # This operation might await other tasks first
-        )
-        return resp
 
     @classmethod
     def _register_mapping(

--- a/src/steamship/invocable/lambda_handler.py
+++ b/src/steamship/invocable/lambda_handler.py
@@ -33,6 +33,7 @@ def internal_handler(  # noqa: C901
     invocable_cls_func: Callable[[], Type[Invocable]],
     event: Dict,
     client: Steamship,
+    invocation_context: InvocationContext,
 ) -> InvocableResponse:
 
     try:
@@ -56,7 +57,9 @@ def internal_handler(  # noqa: C901
         error_prefix = "[ERROR - ?VERB ?PATH] "
 
     try:
-        invocable = invocable_cls_func()(client=client, config=request.invocation.config)
+        invocable = invocable_cls_func()(
+            client=client, config=request.invocation.config, context=invocation_context
+        )
     except SteamshipError as se:
         logging.exception(se)
         return InvocableResponse.from_obj(se)
@@ -179,7 +182,7 @@ def handler(internal_handler, event: Dict, _: Dict = None) -> dict:  # noqa: C90
             exception=ex,
         ).dict(by_alias=True)
     logging.info(f"Localstack hostname: {environ.get('LOCALSTACK_HOSTNAME')}.")
-    response = internal_handler(event, client)
+    response = internal_handler(event, client, invocation_context)
 
     result = response.dict(by_alias=True, exclude={"client"})
     # When created with data > 4MB, data is uploaded to a bucket.
@@ -273,8 +276,8 @@ def create_safe_handler(known_invocable_for_testing: Type[Invocable] = None):
         invocable_getter = lambda: known_invocable_for_testing  # noqa: E731
     else:
         invocable_getter = safely_find_invocable_class
-    bound_internal_handler = lambda event, client: internal_handler(  # noqa: E731
-        invocable_getter, event, client
+    bound_internal_handler = lambda event, client, context: internal_handler(  # noqa: E731
+        invocable_getter, event, client, context
     )
     return lambda event, context=None: handler(bound_internal_handler, event, context)
 

--- a/src/steamship/invocable/package_service.py
+++ b/src/steamship/invocable/package_service.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import logging
+from typing import Any, Dict, List
+
+from steamship import SteamshipError, Task
 from steamship.invocable import Invocable
 
 # Note!
@@ -8,6 +12,7 @@ from steamship.invocable import Invocable
 # This the files in this package are for Package Implementors.
 # If you are using the Steamship Client, you probably are looking for either steamship.client or steamship.data
 #
+from steamship.utils.url import Verb
 
 
 class PackageService(Invocable):
@@ -19,3 +24,61 @@ class PackageService(Invocable):
     Package *implementations* are effectively stateless, though they will have stateful
 
     """
+
+    def invoke_later(
+        self,
+        method: str,
+        verb: Verb = Verb.POST,
+        wait_on_tasks: List[Task] = None,
+        arguments: Dict[str, Any] = None,
+    ) -> Task[Any]:
+        """Schedule a method for future invocation.
+
+        Parameters
+        ----------
+        method: str
+                The method to invoke, as registered with Steamship in the @get or @post decorator.
+        verb:   Verb
+                The HTTP Verb to use. Default is POST.
+        wait_on_tasks: List[Task]
+                A list of Task objects (or task IDs) that should be waited upon before invocation.
+        arguments: Dict[str, Any]
+                The keyword arguments of the invoked method
+
+        Returns
+        -------
+        Task[Any]
+                A Task representing the future work
+        """
+
+        if self.context is None:
+            raise SteamshipError(
+                message="Unable to call invoke_later because the InvocationContext was None"
+            )
+        if self.context.invocable_instance_handle is None:
+            raise SteamshipError(
+                message="Unable to call invoke_later because the invocable_instance_handle on InvocationContext was None"
+            )
+
+        payload = {
+            "instanceHandle": self.context.invocable_instance_handle,
+            "payload": {
+                "httpVerb": verb.value,
+                "invocationPath": method,
+                "arguments": arguments or {},
+            },
+        }
+        operation = "package/instance/invoke"
+
+        logging.info(
+            f"Scheduling {verb} {method} for future invocation on me ({self.context.invocable_handle})"
+        )
+
+        resp = self.client.post(
+            operation,
+            payload,
+            expect=Task[Task],  # This operation should return a task
+            as_background_task=True,  # This operation should always be asynchronous
+            wait_on_tasks=wait_on_tasks,  # This operation might await other tasks first
+        )
+        return resp

--- a/src/steamship/invocable/package_service.py
+++ b/src/steamship/invocable/package_service.py
@@ -43,7 +43,7 @@ class PackageService(Invocable):
         wait_on_tasks: List[Task]
                 A list of Task objects (or task IDs) that should be waited upon before invocation.
         arguments: Dict[str, Any]
-                The keyword arguments of the invoked method
+                The keyword arguments of the invoked   method
 
         Returns
         -------

--- a/src/steamship/invocable/plugin_service.py
+++ b/src/steamship/invocable/plugin_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Generic, Type, TypeVar, Union
+from typing import Generic, Type, TypeVar, Union
 
 # Note!
 # =====
@@ -10,7 +10,6 @@ from typing import Any, Dict, Generic, Type, TypeVar, Union
 # This the files in this package are for Plugin Implementors.
 # If you are using the Steamship Client, you probably are looking for either steamship.client or steamship.data
 #
-from steamship.client import Steamship
 from steamship.invocable import Invocable, InvocableResponse
 from steamship.plugin.inputs.train_plugin_input import TrainPluginInput
 from steamship.plugin.inputs.training_parameter_plugin_input import TrainingParameterPluginInput
@@ -61,10 +60,6 @@ class PluginService(Invocable, Generic[IN, OUT], ABC):
 
 
 class TrainablePluginService(PluginService, Generic[IN, OUT], ABC):
-    # noinspection PyUnusedLocal
-    def __init__(self, client: Steamship = None, config: Dict[str, Any] = None):
-        super().__init__(client, config)
-
     @abstractmethod
     def model_cls(self) -> Type[TrainableModel]:
         """Returns the constructor of the TrainableModel this TrainablePluginService uses.

--- a/tests/assets/demo_package_spec.json
+++ b/tests/assets/demo_package_spec.json
@@ -81,6 +81,22 @@
       "config": {},
       "verb": "POST"
     },
+     {
+         "args": [{"kind": "<class 'str'>", "name": "name"}],
+         "config": {},
+         "doc": null,
+         "path": "/future_greet",
+         "returns": "<class 'foo.InvocableResponse[Task]'>",
+         "verb": "POST"
+     },
+     {
+         "args": [{"kind": "<class 'str'>", "name": "name"}],
+         "config": {},
+         "doc": null,
+         "path": "/future_greet_then_greet_again",
+         "returns": "<class 'foo.InvocableResponse[Task]'>",
+         "verb": "POST"
+     },
     {
       "path": "/workspace",
       "doc": null,

--- a/tests/assets/plugins/blockifiers/tsv_blockifier.py
+++ b/tests/assets/plugins/blockifiers/tsv_blockifier.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 from assets.plugins.blockifiers.csv_blockifier import CsvBlockifier
 
-from steamship.invocable import create_handler
+from steamship.invocable import InvocationContext, create_handler
 from steamship.plugin.blockifier import Blockifier
 
 
@@ -14,8 +14,10 @@ class TsvBlockifier(CsvBlockifier, Blockifier):
     Implementation is only here to demonstrate how plugins can be built through inheritance.
     """
 
-    def __init__(self, client=None, config: Dict[str, Any] = None):
-        super().__init__(client, config)
+    def __init__(
+        self, client=None, config: Dict[str, Any] = None, context: InvocationContext = None
+    ):
+        super().__init__(client, config, context)
         self.config.delimiter = "\t"
 
 

--- a/tests/assets/plugins/taggers/plugin_trainable_tagger.py
+++ b/tests/assets/plugins/taggers/plugin_trainable_tagger.py
@@ -1,11 +1,10 @@
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Type
+from typing import List, Optional, Type
 
 from steamship import File, SteamshipError, Tag
 from steamship.base import Task, TaskState
-from steamship.base.client import Client
 from steamship.invocable import Config, InvocableResponse, create_handler
 from steamship.plugin.inputs.block_and_tag_plugin_input import BlockAndTagPluginInput
 from steamship.plugin.inputs.train_plugin_input import TrainPluginInput
@@ -131,9 +130,6 @@ class TestTrainableTaggerPlugin(TrainableTagger):
     - It could be orchestrated from here, but runs in HuggingFace / SageMaker / or elsewhere
 
     """
-
-    def __init__(self, client: Client, config: Dict[str, Any] = None):
-        super().__init__(client, config)
 
     def config_cls(self) -> Type[Config]:
         return EmptyConfig

--- a/tests/assets/plugins/taggers/plugin_trainable_tagger_config.py
+++ b/tests/assets/plugins/taggers/plugin_trainable_tagger_config.py
@@ -1,9 +1,8 @@
 import logging
 from pathlib import Path
-from typing import Any, Dict, Type
+from typing import Type
 
 from steamship import File
-from steamship.base.client import Client
 from steamship.invocable import Config, InvocableResponse, create_handler
 from steamship.plugin.inputs.block_and_tag_plugin_input import BlockAndTagPluginInput
 from steamship.plugin.inputs.train_plugin_input import TrainPluginInput
@@ -73,9 +72,6 @@ class TestTrainableTaggerConfigPlugin(TrainableTagger):
     - It could be orchestrated from here, but runs in HuggingFace / SageMaker / or elsewhere
 
     """
-
-    def __init__(self, client: Client, config: Dict[str, Any] = None):
-        super().__init__(client, config)
 
     def config_cls(self) -> Type[Config]:
         return TestConfig

--- a/tests/steamship_tests/app/unit/test_demo_app_spec.py
+++ b/tests/steamship_tests/app/unit/test_demo_app_spec.py
@@ -11,7 +11,7 @@ def test_package_spec(invocable_handler: Callable[[str, str, Optional[dict]], di
 
     assert rd.get("doc") is None
     assert rd.get("methods") is not None
-    assert len(rd.get("methods")) == 16
+    assert len(rd.get("methods")) == 18
 
     saw_public = False
 

--- a/tests/steamship_tests/utils/fixtures.py
+++ b/tests/steamship_tests/utils/fixtures.py
@@ -71,7 +71,7 @@ def invocable_handler(request) -> Callable[[str, str, Optional[dict]], dict]:
             client_config=new_client.config,
             invocation=invocation,
             logging_config=logging_config,
-            invocation_context=InvocationContext(),
+            invocation_context=InvocationContext(invocable_handle="foo"),
         )
         event = request.dict(by_alias=True)
         return _handler(event, None)


### PR DESCRIPTION
**Tests green against `engine@main` but will fail on prod/staging since they're not up to date**

This adds a new method to the `Invocable` class called `invoke_later` which schedules an invocation against that Invocable's own method call. This enables sequences of long-running operations to be chained together by a package.

In order to implement this, a new variable needed to be passed into the Invocable -- the InvocationContext. That is now a piece of the base-class init method and has to be plumbed down by any plugins/packages that choose to implement their own custom init.