### PR TITLE
feat: add support for directory listing without creating an instance

### DIFF
--- a/src/steamship/invocable/lambda_handler.py
+++ b/src/steamship/invocable/lambda_handler.py
@@ -57,7 +57,8 @@ def internal_handler(  # noqa: C901
 
     if request.invocation.invocation_path == "/__dir__":
         # Return the DIR result without (1) Constructing invocable_cls or (2) Parsing its config (in the constructor)
-        return InvocableResponse(json=invocable_cls_func().__steamship_dir__(invocable_cls_func()))
+        cls = invocable_cls_func()
+        return InvocableResponse(json=cls.__steamship_dir__(cls))
 
     try:
         invocable = invocable_cls_func()(client=client, config=request.invocation.config)

--- a/src/steamship/invocable/lambda_handler.py
+++ b/src/steamship/invocable/lambda_handler.py
@@ -55,6 +55,10 @@ def internal_handler(  # noqa: C901
     else:
         error_prefix = "[ERROR - ?VERB ?PATH] "
 
+    if request.invocation.invocation_path == "/__dir__":
+        # Return the DIR result without (1) Constructing invocable_cls or (2) Parsing its config (in the constructor)
+        return InvocableResponse(json=invocable_cls_func().__steamship_dir__(invocable_cls_func()))
+
     try:
         invocable = invocable_cls_func()(client=client, config=request.invocation.config)
     except SteamshipError as se:

--- a/tests/steamship_tests/app/unit/test_demo_app_spec.py
+++ b/tests/steamship_tests/app/unit/test_demo_app_spec.py
@@ -1,6 +1,7 @@
 from typing import Callable, Optional
 
 import pytest
+from assets.packages.configurable_hello_world import HelloWorld
 from assets.packages.demo_package import TestPackage
 
 
@@ -29,3 +30,15 @@ def test_package_spec(invocable_handler: Callable[[str, str, Optional[dict]], di
             assert method.get("config") == {}
 
     assert saw_public
+
+
+@pytest.mark.parametrize("invocable_handler", [HelloWorld], indirect=True)
+def test_package_spec_missing_configuration(
+    invocable_handler: Callable[[str, str, Optional[dict]], dict]
+):
+    """Test that the handler returns the proper directory information, even for a configuration-required invocable."""
+    rd = invocable_handler("GET", "/__dir__", {}).get("data")
+
+    assert rd.get("doc") is None
+    assert rd.get("methods") is not None
+    assert len(rd.get("methods")) == 4


### PR DESCRIPTION
Required to allow use of `/__dir__`-based healthchecks against "fake" instances that are not fully-configured. This will allow additional confidence that a package version can be used (and marked as default, etc.)