### PR TITLE
[SHIP-511] Add easier version of PluginInstance.train

### DIFF
--- a/src/steamship/data/plugin/plugin_instance.py
+++ b/src/steamship/data/plugin/plugin_instance.py
@@ -18,6 +18,7 @@ from steamship.data.plugin import (
     HostingTimeout,
     HostingType,
 )
+from steamship.plugin.inputs.export_plugin_input import ExportPluginInput
 from steamship.plugin.inputs.training_parameter_plugin_input import TrainingParameterPluginInput
 from steamship.plugin.outputs.train_plugin_output import TrainPluginOutput
 from steamship.plugin.outputs.training_parameter_plugin_output import TrainingParameterPluginOutput
@@ -32,6 +33,9 @@ class CreatePluginInstanceRequest(Request):
     handle: str = None
     fetch_if_exists: bool = None
     config: Dict[str, Any] = None
+
+
+SIGNED_URL_EXPORTER_INSTANCE_HANDLE = "signed-url-exporter-1.0"
 
 
 class PluginInstance(CamelModel):
@@ -113,10 +117,33 @@ class PluginInstance(CamelModel):
         req = DeleteRequest(id=self.id)
         return self.client.post("plugin/instance/delete", payload=req, expect=PluginInstance)
 
-    def train(self, training_request: TrainingParameterPluginInput) -> Task[TrainPluginOutput]:
+    def train(
+        self,
+        training_request: TrainingParameterPluginInput = None,
+        training_epochs: Optional[int] = None,
+        export_query: Optional[str] = None,
+        testing_holdout_percent: Optional[float] = None,
+        test_split_seed: Optional[int] = None,
+        training_params: Optional[Dict] = None,
+        inference_params: Optional[Dict] = None,
+    ) -> Task[TrainPluginOutput]:
+        """Train a plugin instance.  Please provide either training_request OR the other parameters; passing
+        training_request ignores all other parameters, but is kept for backwards compatibility.
+        """
+        input_params = training_request or TrainingParameterPluginInput(
+            plugin_instance=self.handle,
+            training_epochs=training_epochs,
+            export_plugin_input=ExportPluginInput(
+                plugin_instance=SIGNED_URL_EXPORTER_INSTANCE_HANDLE, type="file", query=export_query
+            ),
+            testing_holdout_percent=testing_holdout_percent,
+            test_split_seed=test_split_seed,
+            training_params=training_params,
+            inference_params=inference_params,
+        )
         return self.client.post(
             "plugin/instance/train",
-            payload=training_request,
+            payload=input_params,
             expect=TrainPluginOutput,
         )
 

--- a/tests/steamship_tests/plugin/integration/test_e2e_trainable_tagger.py
+++ b/tests/steamship_tests/plugin/integration/test_e2e_trainable_tagger.py
@@ -110,3 +110,81 @@ def test_e2e_trainable_tagger_lambda_training(client: Steamship):
                 assert res.output.file.tags is not None
                 assert len(res.output.file.tags) == len(KEYWORDS)
                 assert sorted([tag.kind for tag in res.output.file.tags]) == sorted(KEYWORDS)
+
+
+@pytest.mark.usefixtures("client")
+def test_e2e_trainable_tagger_lambda_training_new_train_params(client: Steamship):
+    version_config_template = {
+        "text_column": {"type": "string"},
+        "tag_columns": {"type": "string"},
+        "tag_kind": {"type": "string"},
+    }
+    instance_config = {"text_column": "Message", "tag_columns": "Category", "tag_kind": "Intent"}
+
+    csv_blockifier_path = PLUGINS_PATH / "blockifiers" / "csv_blockifier.py"
+    trainable_tagger_path = PLUGINS_PATH / "taggers" / "plugin_trainable_tagger.py"
+
+    # Make a blockifier which will generate our trainable corpus
+    with deploy_plugin(
+        client,
+        csv_blockifier_path,
+        "blockifier",
+        version_config_template=version_config_template,
+        instance_config=instance_config,
+    ) as (plugin, version, instance):
+        with upload_file(client, "utterances.csv") as file:
+            assert len(file.refresh().blocks) == 0
+            # Use the plugin we just registered
+            file.blockify(plugin_instance=instance.handle).wait()
+            assert len(file.refresh().blocks) == 5
+
+            # Now make a trainable tagger to train on those tags
+            with deploy_plugin(
+                client, trainable_tagger_path, "tagger", training_platform=HostingType.LAMBDA
+            ) as (tagger, tagger_version, tagger_instance):
+
+                train_result = tagger_instance.train(
+                    export_query='kind "foo1"',
+                    training_params={
+                        "keyword_list": KEYWORDS  # This is a key defined by the test model we're training
+                    },
+                )
+                train_result.wait()
+
+                # At this point, the PluginInstance will have written a parameter file to disk. We should be able to
+                # retrieve it since we know that it is tagged as the `default`.
+
+                checkpoint = ModelCheckpoint(
+                    client=client,
+                    handle="default",
+                    plugin_instance_id=tagger_instance.id,
+                )
+                checkpoint_path = checkpoint.download_model_bundle()
+                assert checkpoint_path.exists()
+                keyword_path = Path(checkpoint_path) / TestTrainableTaggerModel.KEYWORD_LIST_FILE
+                assert keyword_path.exists()
+                with open(keyword_path, "r") as f:
+                    params = json.loads(f.read())
+                    assert params == KEYWORDS
+
+                logging.info("Waiting 15 seconds for instance to deploy.")
+                import time
+
+                time.sleep(15)
+
+                # If we're here, we have verified that the plugin instance has correctly recorded its parameters
+                # into the pluginData bucket under a path unique to the PluginInstnace/ModelCheckpoint.
+
+                # Now we'll attempt to USE this plugin. This plugin's behavior is to simply tag any file with the
+                # tags that parameter it. Since those tags are (see above) ["product", "coupon"] we should expect
+                # this tagger to apply those tags to any file provided to it.
+
+                # First we'll create a file
+                test_doc = "Hi there"
+                res = tagger_instance.tag(doc=test_doc)
+                res.wait()
+                assert res.output is not None
+                assert res.output.file is not None
+                assert res.output.file.tags is not None
+                assert len(res.output.file.tags) == len(KEYWORDS)
+                assert sorted([tag.kind for tag in res.output.file.tags]) == sorted(KEYWORDS)


### PR DESCRIPTION
Add more params to train method, allowing one-line invocation, and avoiding the possibility of passing a different plugin instance.  Leave the old way for back-compat.