### PR TITLE
Playing around with simplified prompt interface

### DIFF
--- a/docs/api/steamship.invocable.rst
+++ b/docs/api/steamship.invocable.rst
@@ -60,6 +60,14 @@ steamship.invocable.package\_service module
    :undoc-members:
    :show-inheritance:
 
+steamship.invocable.paramater\_types module
+-------------------------------------------
+
+.. automodule:: steamship.invocable.paramater_types
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 steamship.invocable.plugin\_service module
 ------------------------------------------
 

--- a/docs/packages/cookbook/index.rst
+++ b/docs/packages/cookbook/index.rst
@@ -30,3 +30,16 @@ Building Packages
    Receive webhooks from another service <receiving-webhooks>
 
 
+Response Types
+~~~~~~~~~~~~~~
+
+.. toctree::
+   :maxdepth: 1
+
+   Returning Text <return-text>
+
+   Returning JSON <return-json>
+
+   Returning Images <return-image>
+
+   Returning Audio <return-audio>

--- a/docs/packages/cookbook/return-audio.rst
+++ b/docs/packages/cookbook/return-audio.rst
@@ -1,0 +1,19 @@
+Returning Audio from a Package Endpoint
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Package endpoints can serve audio files by returning a ``InvocableResponse[bytes]`` object with the proper MIME Type set.
+
+API callers will receive a binary response over HTTP with the appropriate  ``Content-Type`` header, and Steamship's auto-generated Web UI will wrap the response in an audio player widget.
+
+.. code-block:: python
+
+    from steamship.base.mime_types import MimeTypes
+    from steamship.invocable import PackageService, get
+
+    class AudioReturningPackage(PackageService):
+        """This package demonstrates how to return audio from a Steamship package."""
+
+        @get("audio_file")
+        def audio_file(self) -> InvocableResponse[bytes]:
+            _bytes = None # REPLACE: This should be a Python bytes object with MP4 Audio
+            return InvocableResponse(_bytes=_bytes, mime_type=MimeTypes.MP4_AUDIO)

--- a/docs/packages/cookbook/return-image.rst
+++ b/docs/packages/cookbook/return-image.rst
@@ -1,0 +1,19 @@
+Returning an Image from a Package Endpoint
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Package endpoints can serve images by returning a ``InvocableResponse[bytes]`` object with the proper MIME Type set.
+
+API callers will receive a binary response over HTTP with the appropriate  ``Content-Type`` header, and Steamship's auto-generated Web UI will convert the response to an image in the browser.
+
+.. code-block:: python
+
+    from steamship.base.mime_types import MimeTypes
+    from steamship.invocable import PackageService, get
+
+    class ImageReturningSteamshipPackage(PackageService):
+        """This package demonstrates how to return an image from a Steamship package."""
+
+        @get("image_file")
+        def image_file(self) -> InvocableResponse[bytes]:
+            _bytes = None # REPLACE: This should be a Python bytes object with a PNG image
+            return InvocableResponse(_bytes=_bytes, mime_type=MimeTypes.PNG)

--- a/docs/packages/cookbook/return-json.rst
+++ b/docs/packages/cookbook/return-json.rst
@@ -1,0 +1,19 @@
+Returning JSON data from a Package Endpoint
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Package endpoints can serve JSON data by returning a python ``dict`` object from a method.
+
+API callers will receive a JSON response over HTTP with the appropriate  ``Content-Type`` header, and Steamship's auto-generated Web UI will convert the JSON response to a formatted web view.
+
+.. code-block:: python
+
+    from steamship.invocable import PackageService, get
+
+    class JsonReturningSteamshipPackage(PackageService):
+        """This package demonstrates how to return a JSON object from a Steamship package."""
+
+        @get("json_object")
+        def json_object(self) -> dict:
+            return {
+                "greeting": "Hello, world!"
+            }

--- a/docs/packages/cookbook/return-text.rst
+++ b/docs/packages/cookbook/return-text.rst
@@ -1,0 +1,17 @@
+Returning text data from a Package Endpoint
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Package endpoints can serve text data by returning a python ``str`` object from a method.
+
+API callers will receive plain text response over HTTP with the appropriate  ``Content-Type`` header, and Steamship's auto-generated Web UI will convert the text response to a formatted web view and interpret it as Markdown.
+
+.. code-block:: python
+
+    from steamship.invocable import PackageService, get
+
+    class TextReturningSteamshipPackage(PackageService):
+        """This package demonstrates how to return a text object from a Steamship package."""
+
+        @get("text_object")
+        def text_object(self) -> str:
+            return "Hello, world!"

--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -351,6 +351,7 @@ class Client(CamelModel, ABC):
                 to_camel(expect.__name__).replace("package", "invocable"),
                 # Hack since engine uses "App" instead of "Package"
                 "index",
+                "pluginInstance",  # Inlined here since `expect` may be a subclass of pluginInstance
             ):
                 # TODO (enias): Hack since the engine responds with incosistent formats e.g. {"plugin" : {plugin_fields}}
                 for _, v in response_data.items():

--- a/src/steamship/client/steamship.py
+++ b/src/steamship/client/steamship.py
@@ -28,6 +28,8 @@ class Steamship(Client):
     _PLUGIN_INSTANCE_SUBCLASS_OVERRIDES = {
         "prompt-generation-default": PromptGenerationPluginInstance,
         "prompt-generation-trainable-default": PromptGenerationPluginInstance,
+        "gpt3": PromptGenerationPluginInstance,
+        "gpt-3": PromptGenerationPluginInstance,
         "embedding-index": EmbeddingIndexPluginInstance,
     }
 

--- a/src/steamship/client/steamship.py
+++ b/src/steamship/client/steamship.py
@@ -154,11 +154,6 @@ class Steamship(Client):
         )
 
     @staticmethod
-    def register_plugin_instance_subclass(plugin_handle: str, plugin_class: PluginInstance):
-        """Register that subclass `plugin_class` should be used for instances of plugin handle `plugin_handle`."""
-        Steamship._PLUGIN_INSTANCE_SUBCLASS_OVERRIDES[plugin_handle] = plugin_class
-
-    @staticmethod
     def use_plugin(
         plugin_handle: str,
         instance_handle: Optional[str] = None,

--- a/src/steamship/data/plugin/index_plugin_instance.py
+++ b/src/steamship/data/plugin/index_plugin_instance.py
@@ -19,11 +19,6 @@ class EmbedderInvocation(CamelModel):
     fetch_if_exists: bool = True
 
 
-# Hard coded list of plugin handles that the Steamship client will use to create
-# instance of this object instead of a normal PluginInstance.
-SHIMMED_INDEX_PLUGIN_HANDLES = ["embedding-index"]
-
-
 class SearchResult(CamelModel):
     """A single scored search result -- which is always a tag.
 
@@ -181,8 +176,6 @@ class EmbeddingIndexPluginInstance(PluginInstance):
         config: Dict[str, Any] = None,
     ) -> "EmbeddingIndexPluginInstance":
         """Create a class that simulates an embedding index re-implemented as a PluginInstance."""
-        if plugin_handle not in SHIMMED_INDEX_PLUGIN_HANDLES:
-            raise SteamshipError(message=f"No Embedding Index of type {plugin_handle} was found.")
 
         # Perform a manual config validation check since the configuration isn't actually being sent up to the Engine.
         # In this case, an embedding index has special behavior which is to instantiate/fetch an Embedder that it can use.

--- a/src/steamship/data/plugin/prompt_generation_plugin_instance.py
+++ b/src/steamship/data/plugin/prompt_generation_plugin_instance.py
@@ -56,9 +56,11 @@ class PromptGenerationPluginInstance(PluginInstance):
                         else:
                             return generation
         except Exception as e:
-            logging.error("generate() got unexpected response shape back.")
+            logging.error(
+                "generate() got unexpected response shape back. This suggests an error rather an merely an empty response."
+            )
             logging.exception(e)
-            return ""
+            raise e
         return ""
 
     @staticmethod

--- a/src/steamship/data/plugin/prompt_plugin_instance.py
+++ b/src/steamship/data/plugin/prompt_plugin_instance.py
@@ -5,7 +5,14 @@ from steamship.data.tags.tag_constants import TagKind, TagValueKey
 
 
 class PromptPluginInstance(PluginInstance):
-    """An instance of a configured prompt-completion service.s"""
+    """An instance of a configured prompt-completion service.
+
+    Usage:
+       llm = Steamship.use('llm', config={ args })
+
+       PROMPT = "Greet {name} as if he were a {relation}."
+       greeting = llm.generate(PROMPT, {"name": "Ted", "relation": "old friend"})
+    """
 
     def generate(self, prompt: str, variables: Optional[Dict] = None) -> str:
         """Complete the provided prompt, interpolating any variables."""

--- a/src/steamship/data/plugin/prompt_plugin_instance.py
+++ b/src/steamship/data/plugin/prompt_plugin_instance.py
@@ -1,0 +1,57 @@
+from typing import Dict, Optional
+
+from steamship import Block, File, PluginInstance
+from steamship.data.tags.tag_constants import TagKind, TagValueKey
+
+
+class PromptPluginInstance(PluginInstance):
+    """An instance of a configured prompt-completion service.s"""
+
+    def generate(self, prompt: str, variables: Optional[Dict] = None) -> str:
+        """Complete the provided prompt, interpolating any variables."""
+
+        prompt_text = prompt.format(**variables)
+
+        # Each prompt will be stored in Steamship as a File. The generated text will be
+        # associated with the prompt File via Steamship tags. This enables later retrieval
+        # of prompts and their results (which may be used in subsequent operations, etc.).
+        #
+        # To learn about the Steamship data model, please consult our the docs:
+        # https://docs.steamship.com/workspaces/data_model/index.html
+        file = File.create(self.client, blocks=[Block.CreateRequest(text=prompt_text)])
+
+        # This requests generation from the parameterized prompt. Tagging with our prompt generator
+        # plugin will result in a new tag that contains the generated output.
+        # We `wait()` because generation of text is done asynchronously and may take a few moments
+        # (somewhat depending on the complexity of your prompt).
+        file.tag(plugin_instance=self.handle).wait()
+
+        # Here, we iterate through the content blocks associated with a file
+        # as well as any tags on that content to find the generated text.
+        #
+        # The Steamship data model provides flexible content organization,
+        # storage, and lookup. Read more about the data model via:
+        # https://docs.steamship.com/workspaces/data_model/index.html
+        for text_block in file.blocks:
+            for block_tag in text_block.tags:
+                if block_tag.kind == TagKind.GENERATION:
+                    return self._clean_output(block_tag.value[TagValueKey.STRING_VALUE])
+
+        return ""
+
+    def _clean_output(self, text: str):
+        """Remove any leading/trailing whitespace and partial sentences.
+
+        This assumes that your generated output will include consistent punctuation. You may
+        want to alter this method to better fit the format of your generated text.
+        """
+        last_punc = -1
+        for i, c in enumerate(reversed(text)):
+            if c in '.!?"':
+                last_punc = len(text) - i
+                break
+        if last_punc != -1:
+            result = text[: last_punc + 1]
+        else:
+            result = text
+        return result.strip()

--- a/src/steamship/data/tags/tag.py
+++ b/src/steamship/data/tags/tag.py
@@ -10,7 +10,7 @@ from steamship.base.client import Client
 from steamship.base.model import CamelModel
 from steamship.base.request import Request
 from steamship.base.response import Response
-from steamship.data.tags.tag_constants import TagKind, TagValueKey
+from steamship.data.tags.tag_constants import GenerationTag, TagKind, TagValueKey
 
 
 class TagQueryRequest(Request):
@@ -317,6 +317,23 @@ class EmbeddingTag(Tag):
             start_idx=start_idx,
             end_idx=end_idx,
             value={**value, TagValueKey.VECTOR_VALUE: embedding},
+        )
+
+
+class PromptCompletionTag(Tag):
+    def __init__(
+        self,
+        text: str = None,
+        start_idx: Optional[int] = None,
+        end_idx: Optional[int] = None,
+        value: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(
+            kind=TagKind.GENERATION,
+            name=GenerationTag.PROMPT_COMPLETION,
+            start_idx=start_idx,
+            end_idx=end_idx,
+            value={**value, TagValueKey.STRING_VALUE: text},
         )
 
 

--- a/tests/assets/plugins/taggers/plugin_configurable_tagger.py
+++ b/tests/assets/plugins/taggers/plugin_configurable_tagger.py
@@ -15,7 +15,7 @@ class TestParserPlugin(Tagger):
     class TestParserConfig(Config):
         tag_kind: str
         tag_name: str
-        number_value: Union[int, float]
+        number_value: Optional[Union[int, float]] = None
         # TODO: Check to see if python and/or swift removes False from obj.
         # If this is non-optional, the typecheck fails despite the fact that the test passes
         # in a value of false....

--- a/tests/assets/plugins/taggers/plugin_configurable_tagger.py
+++ b/tests/assets/plugins/taggers/plugin_configurable_tagger.py
@@ -1,6 +1,7 @@
 from typing import Optional, Type, Union
 
 from steamship import Tag
+from steamship.data import TagValueKey
 from steamship.invocable import Config, InvocableResponse, create_handler
 from steamship.invocable.plugin_service import PluginRequest
 from steamship.plugin.inputs.block_and_tag_plugin_input import BlockAndTagPluginInput
@@ -19,6 +20,9 @@ class TestParserPlugin(Tagger):
         # If this is non-optional, the typecheck fails despite the fact that the test passes
         # in a value of false....
         boolean_value: Optional[bool] = False
+        string_value: Optional[str] = ""
+
+    config: TestParserConfig
 
     def config_cls(self) -> Type[Config]:
         return self.TestParserConfig
@@ -29,8 +33,9 @@ class TestParserPlugin(Tagger):
         tag_kind = self.config.tag_kind
         tag_name = self.config.tag_name
         tag_value = {
-            "numberValue": self.config.number_value,
-            "booleanValue": self.config.boolean_value,
+            TagValueKey.NUMBER_VALUE: self.config.number_value,
+            TagValueKey.BOOL_VALUE: self.config.boolean_value,
+            TagValueKey.STRING_VALUE: self.config.string_value,
         }
 
         if request.data is not None:

--- a/tests/assets/plugins/taggers/plugin_prompt_generator.py
+++ b/tests/assets/plugins/taggers/plugin_prompt_generator.py
@@ -13,17 +13,17 @@ class TestPromptGeneratorPlugin(Tagger):
     ) -> InvocableResponse[BlockAndTagPluginOutput]:
         """Merely returns the prompt."""
         request_file = request.data.file
-        output = BlockAndTagPluginOutput(file=File.CreateRequest(id=request_file.id), tags=[])
+        output = BlockAndTagPluginOutput(file=File(id=request_file.id), tags=[])
         for block in request.data.file.blocks:
             text = block.text
             tags = [
-                Tag.CreateRequest(
+                Tag(
                     kind=TagKind.GENERATION,
                     name=GenerationTag.PROMPT_COMPLETION,
                     value={TagValueKey.STRING_VALUE: text},
                 )
             ]
-            output_block = Block.CreateRequest(id=block.id, tags=tags)
+            output_block = Block(id=block.id, tags=tags)
             output.file.blocks.append(output_block)
 
         return InvocableResponse(data=output)

--- a/tests/assets/plugins/taggers/plugin_prompt_generator.py
+++ b/tests/assets/plugins/taggers/plugin_prompt_generator.py
@@ -1,0 +1,32 @@
+from steamship import Block, File, Tag
+from steamship.data import GenerationTag, TagKind, TagValueKey
+from steamship.invocable import InvocableResponse, create_handler
+from steamship.invocable.plugin_service import PluginRequest
+from steamship.plugin.inputs.block_and_tag_plugin_input import BlockAndTagPluginInput
+from steamship.plugin.outputs.block_and_tag_plugin_output import BlockAndTagPluginOutput
+from steamship.plugin.tagger import Tagger
+
+
+class TestPromptGeneratorPlugin(Tagger):
+    def run(
+        self, request: PluginRequest[BlockAndTagPluginInput]
+    ) -> InvocableResponse[BlockAndTagPluginOutput]:
+        """Merely returns the prompt."""
+        request_file = request.data.file
+        output = BlockAndTagPluginOutput(file=File.CreateRequest(id=request_file.id), tags=[])
+        for block in request.data.file.blocks:
+            text = block.text
+            tags = [
+                Tag.CreateRequest(
+                    kind=TagKind.GENERATION,
+                    name=GenerationTag.PROMPT_COMPLETION,
+                    value={TagValueKey.STRING_VALUE: text},
+                )
+            ]
+            output_block = Block.CreateRequest(id=block.id, tags=tags)
+            output.file.blocks.append(output_block)
+
+        return InvocableResponse(data=output)
+
+
+handler = create_handler(TestPromptGeneratorPlugin)

--- a/tests/steamship_tests/plugin/integration/test_e2e_configurable_tagger.py
+++ b/tests/steamship_tests/plugin/integration/test_e2e_configurable_tagger.py
@@ -3,6 +3,7 @@ from steamship_tests.utils.deployables import deploy_plugin
 from steamship_tests.utils.fixtures import get_steamship_client
 
 from steamship import PluginInstance
+from steamship.data import TagValueKey
 
 
 def test_e2e_parser():
@@ -13,12 +14,14 @@ def test_e2e_parser():
         "tagName": {"type": "string"},
         "numberValue": {"type": "number"},
         "booleanValue": {"type": "boolean"},
+        "stringValue": {"type": "string"},
     }
     instance_config1 = {
         "tagKind": "testTagKind",
         "tagName": "testTagName",
         "numberValue": 3,
         "booleanValue": True,
+        "stringValue": "Hi",
     }
 
     with deploy_plugin(
@@ -41,14 +44,16 @@ def test_e2e_parser():
         assert tag.name == instance_config1["tagName"]
         assert tag.kind == instance_config1["tagKind"]
         tag_value = tag.value
-        assert tag_value["numberValue"] == instance_config1["numberValue"]
-        assert tag_value["booleanValue"] == instance_config1["booleanValue"]
+        assert tag_value[TagValueKey.NUMBER_VALUE] == instance_config1["numberValue"]
+        assert tag_value[TagValueKey.BOOL_VALUE] == instance_config1["booleanValue"]
+        assert tag_value[TagValueKey.STRING_VALUE] == instance_config1["stringValue"]
 
         instance_config2 = {
             "tagKind": "testTagKind2",
             "tagName": "testTagName2",
             "numberValue": 4,
             "booleanValue": False,
+            "stringValue": "Hi",
         }
 
         instance2 = PluginInstance.create(
@@ -71,5 +76,6 @@ def test_e2e_parser():
         assert tag.name == instance_config2["tagName"]
         assert tag.kind == instance_config2["tagKind"]
         tag_value = tag.value
-        assert tag_value["numberValue"] == instance_config2["numberValue"]
-        assert tag_value["booleanValue"] == instance_config2["booleanValue"]
+        assert tag_value[TagValueKey.NUMBER_VALUE] == instance_config2["numberValue"]
+        assert tag_value[TagValueKey.BOOL_VALUE] == instance_config2["booleanValue"]
+        assert tag_value[TagValueKey.STRING_VALUE] == instance_config2["stringValue"]

--- a/tests/steamship_tests/plugin/integration/test_e2e_prompt_plugin.py
+++ b/tests/steamship_tests/plugin/integration/test_e2e_prompt_plugin.py
@@ -1,0 +1,49 @@
+from steamship_tests import PLUGINS_PATH
+from steamship_tests.utils.client import steamship_use_plugin
+from steamship_tests.utils.deployables import deploy_plugin
+from steamship_tests.utils.fixtures import get_steamship_client
+
+from steamship.client.steamship import Steamship
+from steamship.data import TagKind
+from steamship.data.plugin.prompt_generation_plugin_instance import PromptGenerationPluginInstance
+
+
+def test_use_prompt():
+    fixed_prompt_response = "You can tune a guitar, but you can't guitar a tuna!"
+
+    client = get_steamship_client()
+    tagger_plugin_path = PLUGINS_PATH / "taggers" / "plugin_configurable_tagger.py"
+    config_template = {
+        "tagKind": {"type": "string"},
+        "tagName": {"type": "string"},
+        "numberValue": {"type": "number"},
+        "booleanValue": {"type": "boolean"},
+        "stringValue": {"type": "string"},
+    }
+    instance_config1 = {
+        "tagKind": TagKind.GENERATION.value,
+        "tagName": "testTagName",
+        "numberValue": 3,
+        "booleanValue": True,
+        "stringValue": fixed_prompt_response,
+    }
+
+    with deploy_plugin(
+        client,
+        tagger_plugin_path,
+        "tagger",
+        version_config_template=config_template,
+        instance_config=instance_config1,
+    ) as (plugin, version, instance):
+        # Add this plugin to the list which will be cast into the PromptCompletionPluginInstance class.
+        Steamship.register_plugin_shim(plugin.handle, PromptGenerationPluginInstance)
+
+        # Now we just invoke use_plugin.
+        # Note: this just applies Steamship.use_plugin with the same testing environment as the unit tests.
+        llm = steamship_use_plugin(plugin.handle, version=version.handle)
+
+        # And we can run a prompt
+        result = llm.generate("This is my prompt", {})
+
+        # The result should be a string equal to the preset string of this (fake) prompt completion plugin
+        assert fixed_prompt_response == result

--- a/tests/steamship_tests/plugin/integration/test_e2e_prompt_plugin.py
+++ b/tests/steamship_tests/plugin/integration/test_e2e_prompt_plugin.py
@@ -1,49 +1,38 @@
+import pytest
 from steamship_tests import PLUGINS_PATH
 from steamship_tests.utils.client import steamship_use_plugin
 from steamship_tests.utils.deployables import deploy_plugin
 from steamship_tests.utils.fixtures import get_steamship_client
 
+from steamship import SteamshipError
 from steamship.client.steamship import Steamship
-from steamship.data import TagKind
 from steamship.data.plugin.prompt_generation_plugin_instance import PromptGenerationPluginInstance
 
 
 def test_use_prompt():
-    fixed_prompt_response = "You can tune a guitar, but you can't guitar a tuna!"
 
     client = get_steamship_client()
-    tagger_plugin_path = PLUGINS_PATH / "taggers" / "plugin_configurable_tagger.py"
-    config_template = {
-        "tagKind": {"type": "string"},
-        "tagName": {"type": "string"},
-        "numberValue": {"type": "number"},
-        "booleanValue": {"type": "boolean"},
-        "stringValue": {"type": "string"},
-    }
-    instance_config1 = {
-        "tagKind": TagKind.GENERATION.value,
-        "tagName": "testTagName",
-        "numberValue": 3,
-        "booleanValue": True,
-        "stringValue": fixed_prompt_response,
-    }
+    tagger_plugin_path = PLUGINS_PATH / "taggers" / "plugin_prompt_generator.py"
 
     with deploy_plugin(
         client,
         tagger_plugin_path,
         "tagger",
-        version_config_template=config_template,
-        instance_config=instance_config1,
     ) as (plugin, version, instance):
         # Add this plugin to the list which will be cast into the PromptCompletionPluginInstance class.
-        Steamship.register_plugin_shim(plugin.handle, PromptGenerationPluginInstance)
+        Steamship.register_plugin_instance_subclass(plugin.handle, PromptGenerationPluginInstance)
 
         # Now we just invoke use_plugin.
         # Note: this just applies Steamship.use_plugin with the same testing environment as the unit tests.
-        llm = steamship_use_plugin(plugin.handle, version=version.handle)
+        with steamship_use_plugin(plugin.handle, delete_workspace=True) as llm:
+            # And we can run a prompt. Covering some bases to encode edge cases and their expected behavior.
 
-        # And we can run a prompt
-        result = llm.generate("This is my prompt", {})
-
-        # The result should be a string equal to the preset string of this (fake) prompt completion plugin
-        assert fixed_prompt_response == result
+            # Prompt vars: 1, Provided vars: 1
+            assert llm.generate("Hello, {name}!", {"name": "world"}) == "Hello, world!"
+            # Prompt vars: 0, Provided vars: 1
+            assert llm.generate("Hello, World!", {"name": "world"}) == "Hello, World!"
+            # Prompt vars: 1, Provided vars: 0
+            with pytest.raises(SteamshipError):
+                assert llm.generate("Hello, {name}!") == "Hello, {name}!"
+            # Prompt vars: 0, Provided vars: 0
+            assert llm.generate("Hello, World!") == "Hello, World!"

--- a/tests/steamship_tests/plugin/integration/test_e2e_prompt_plugin.py
+++ b/tests/steamship_tests/plugin/integration/test_e2e_prompt_plugin.py
@@ -1,11 +1,10 @@
 import pytest
 from steamship_tests import PLUGINS_PATH
-from steamship_tests.utils.client import steamship_use_plugin
+from steamship_tests.utils.client import register_plugin_instance_subclass, steamship_use_plugin
 from steamship_tests.utils.deployables import deploy_plugin
 from steamship_tests.utils.fixtures import get_steamship_client
 
 from steamship import SteamshipError
-from steamship.client.steamship import Steamship
 from steamship.data.plugin.prompt_generation_plugin_instance import PromptGenerationPluginInstance
 
 
@@ -20,7 +19,7 @@ def test_use_prompt():
         "tagger",
     ) as (plugin, version, instance):
         # Add this plugin to the list which will be cast into the PromptCompletionPluginInstance class.
-        Steamship.register_plugin_instance_subclass(plugin.handle, PromptGenerationPluginInstance)
+        register_plugin_instance_subclass(plugin.handle, PromptGenerationPluginInstance)
 
         # Now we just invoke use_plugin.
         # Note: this just applies Steamship.use_plugin with the same testing environment as the unit tests.

--- a/tests/steamship_tests/plugin/integration/test_use_skill.py
+++ b/tests/steamship_tests/plugin/integration/test_use_skill.py
@@ -6,6 +6,7 @@ from steamship_tests.utils.fixtures import get_steamship_client
 
 from steamship import SteamshipError
 from steamship.client.steamship import SKILL_TO_PROVIDER
+from steamship.data import TagValueKey
 
 
 def test_use_skill():
@@ -76,5 +77,5 @@ def _test_skill_instance(skill_instance_1, test_str):
     config = SKILL_TO_PROVIDER["hello"]["steamship"]["config"]
     assert tag.name == config["tagName"]
     assert tag.kind == config["tagKind"]
-    assert tag.value["numberValue"] == config["numberValue"]
-    assert tag.value["booleanValue"] == config["booleanValue"]
+    assert tag.value[TagValueKey.NUMBER_VALUE] == config["numberValue"]
+    assert tag.value[TagValueKey.BOOL_VALUE] == config["booleanValue"]

--- a/tests/steamship_tests/utils/client.py
+++ b/tests/steamship_tests/utils/client.py
@@ -80,3 +80,8 @@ def steamship_use_skill(
     # Clean up the workspace
     if delete_workspace:
         instance.client.get_workspace().delete()
+
+
+def register_plugin_instance_subclass(plugin_handle: str, plugin_class: PluginInstance):
+    """Register that subclass `plugin_class` should be used for instances of plugin handle `plugin_handle`."""
+    Steamship._PLUGIN_INSTANCE_SUBCLASS_OVERRIDES[plugin_handle] = plugin_class


### PR DESCRIPTION
## Description

This PR introduces our second PluginInstance subclass -- `PromptGenerationPluginInstance`.

It changes no semantics of how plugins, tagging, or existing LLM plugins work; it only acts as a convenience wrapper around PluginInstances that happen to be associated with an LLM tagger.

* It adds a `generate(prompt, prompt_variables)` method which synchronously returns a string.
* It adds an output sanitization method.

## Example Usage

Using this new subclass, one can invoke an LLM with two lines of code and two lines of data:

```
PROMPT = "Greet {name} as if he were a {relation}."
VARIABLES = { "name": "Ted", "relation": "friend" }

llm = Steamship.use('prompt-generation-default', config={ "temperature": 0.9 })
greeting = llm.generate(PROMPT, VARIABLES)
```

## Implementation

* The implementation of `generate` is copy-pasted directly from our current prompt-api template. The intention is to simplify our code with as small as possible a change in present-day mechanics.
* The knowledge of when to use this subclass is hard-coded into our client, as we do with embedding indices, which seems OK since at most there are only 4-5 LLM providers that matter at present.