### PR TITLE
Python Mini CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ description = "The fastest way to add language AI to your product."
 dynamic = ["dependencies", "version"]
 readme = "README.md"
 
+[project.scripts]
+shippy = "steamship.cli.cli:cli"
+
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dynamic = ["dependencies", "version"]
 readme = "README.md"
 
 [project.scripts]
-shippy = "steamship.cli.cli:cli"
+ship = "steamship.cli.cli:cli"
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ aiohttp==3.8.3
 inflection==0.5.1
 fluent-logger==0.10.0
 toml==0.10.2
+click==8.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ inflection==0.5.1
 fluent-logger==0.10.0
 toml==0.10.2
 click==8.1.3
+semver==2.13.0

--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -79,6 +79,7 @@ class Client(CamelModel, ABC):
         if config is not None and not isinstance(config, Configuration):
             config = Configuration.parse_obj(config)
 
+        self._session = Session()
         config = config or Configuration(
             api_key=api_key,
             api_base=api_base,
@@ -88,7 +89,7 @@ class Client(CamelModel, ABC):
             profile=profile,
             config_file=config_file,
         )
-        self._session = Session()
+
         super().__init__(config=config)
         # The lambda_handler will pass in the workspace via the workspace_id, so we need to plumb this through to make sure
         # that the workspace switch performed doesn't mistake `workspace=None` as a request for the default workspace

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -1,0 +1,26 @@
+import sys
+
+from steamship import Steamship
+from steamship.base.configuration import Configuration
+from steamship.data.user import User
+
+
+def cli():
+    if len(sys.argv) != 2 or sys.argv[1] not in ["login", "deploy"]:
+        print("Only options are login or deploy.")
+        sys.exit(-1)
+    else:
+        print("Logging into Steamship.")
+        if sys.argv[1] == "login":
+            if Configuration.default_config_file_has_api_key():
+                response = input(
+                    "You already have an API key in your .steamship.json file.  Do you want to remove it and login? [y/n] "
+                )
+                if response.lower() != "y":
+                    sys.exit(0)
+                Configuration.remove_api_key_from_default_config()
+
+            # Carry on with login
+            client = Steamship()
+            user = User.current(client)
+            print(f"🚢🚢🚢 Hooray! You're logged in with user handle: {user.handle} 🚢🚢🚢")

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -79,7 +79,7 @@ def deploy():
 
     thing_url = f"{client.config.web_base}{thing_type}s/{manifest.handle}"
     click.echo(
-        f"Deployment was successful. View and share your new {thing_type} here:\n\n{thing_url}"
+        f"Deployment was successful. View and share your new {thing_type} here:\n\n{thing_url}\n"
     )
 
     # Common error conditions:

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -1,13 +1,15 @@
 import sys
-import time
 from os import path
 
 import click
 
-from steamship import Steamship
+import steamship
+from steamship import Steamship, SteamshipError
 from steamship.base.configuration import Configuration
+from steamship.cli.deploy import PackageDeployer, bundle_deployable, update_config_template
 from steamship.cli.manifest_init_wizard import manifest_init_wizard
 from steamship.data.user import User
+from steamship.invocable.manifest import DeployableType, Manifest
 
 
 @click.group()
@@ -15,8 +17,13 @@ def cli():
     pass
 
 
+def print_info():
+    click.echo(f"Steamship PYTHON cli version {steamship.__version__}")
+
+
 @click.command()
 def login():
+    print_info()
     click.echo("Logging into Steamship.")
     if sys.argv[1] == "login":
         if Configuration.default_config_file_has_api_key():
@@ -40,22 +47,54 @@ def login():
 
 @click.command()
 def deploy():
+    print_info()
     client = Steamship()
-    if not path.exists("steamship.json"):
-        manifest_init_wizard(client)
+    if path.exists("steamship.json"):
+        manifest = Manifest.load_manifest()
+    else:
+        manifest = manifest_init_wizard(client)
+        manifest.save()
 
-    with click.progressbar(
-        length=10,
-        fill_char="🚢",
-        empty_char=" ",
-        show_eta=False,
-        show_percent=False,
-        show_pos=True,
-        label="Shipping your package",
-    ) as bar:
-        for _ in range(10):
-            time.sleep(1)
-            bar.update(1)
+    thing_type = manifest.type
+
+    update_config_template(manifest)
+
+    click.echo("Bundling content... ", nl=False)
+    bundle_deployable(manifest)
+    click.echo("Done. 📦")
+
+    if thing_type == DeployableType.PACKAGE:
+        deployer = PackageDeployer()
+    else:
+        raise SteamshipError("Can only deploy packages right now")
+
+    click.echo(f"Creating / fetching {thing_type} with handle [{manifest.handle}]... ", nl=False)
+    thing = deployer.create_object(client, manifest)
+    click.echo("Done.")
+
+    click.echo(f"Deploying version {manifest.version} of [{manifest.handle}]... ", nl=False)
+    _ = deployer.create_version(client, manifest, thing.id)
+    click.echo("Done. 🚢")
+
+    thing_url = f"{client.config.web_base}{thing_type}s/{manifest.handle}"
+    click.echo(
+        click.style(
+            f"Deployment was successful.  View and share your new {thing_type} here: {thing_url}"
+        )
+    )
+
+    # with click.progressbar(
+    #     length=10,
+    #     fill_char="🚢",
+    #     empty_char=" ",
+    #     show_eta=False,
+    #     show_percent=False,
+    #     show_pos=True,
+    #     label="Shipping your package",
+    # ) as bar:
+    #     for _ in range(10):
+    #         time.sleep(1)
+    #         bar.update(1)
 
 
 cli.add_command(deploy)

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -54,12 +54,12 @@ def deploy():
         manifest = manifest_init_wizard(client)
         manifest.save()
 
-    thing_type = manifest.type
+    deployable_type = manifest.type
 
     update_config_template(manifest)
 
     deployer = None
-    if thing_type == DeployableType.PACKAGE:
+    if deployable_type == DeployableType.PACKAGE:
         deployer = PackageDeployer()
     else:
         click.secho(
@@ -67,17 +67,17 @@ def deploy():
         )
         click.get_current_context().abort()
 
-    thing = deployer.create_or_fetch_thing(client, user, manifest)
+    deployable = deployer.create_or_fetch_deployable(client, user, manifest)
 
     click.echo("Bundling content... ", nl=False)
     bundle_deployable(manifest)
     click.echo("Done. 📦")
 
-    _ = deployer.create_version(client, manifest, thing.id)
+    _ = deployer.create_version(client, manifest, deployable.id)
 
-    thing_url = f"{client.config.web_base}{thing_type}s/{manifest.handle}"
+    thing_url = f"{client.config.web_base}{deployable_type}s/{manifest.handle}"
     click.echo(
-        f"Deployment was successful. View and share your new {thing_type} here:\n\n{thing_url}\n"
+        f"Deployment was successful. View and share your new {deployable_type} here:\n\n{thing_url}\n"
     )
 
     # Common error conditions:

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -73,9 +73,7 @@ def deploy():
     bundle_deployable(manifest)
     click.echo("Done. 📦")
 
-    click.echo(f"Deploying version {manifest.version} of [{manifest.handle}]... ", nl=False)
     _ = deployer.create_version(client, manifest, thing.id)
-    click.echo("Done. 🚢")
 
     thing_url = f"{client.config.web_base}{thing_type}s/{manifest.handle}"
     click.echo(
@@ -83,23 +81,10 @@ def deploy():
     )
 
     # Common error conditions:
-    # - Package/plugin handle already taken.
-    # - Version handle already deployed.
-    # - Bad parameter configuration.
-    # - Package content fails health check (ex. bad import)
-
-    # with click.progressbar(
-    #     length=10,
-    #     fill_char="🚢",
-    #     empty_char=" ",
-    #     show_eta=False,
-    #     show_percent=False,
-    #     show_pos=True,
-    #     label="Shipping your package",
-    # ) as bar:
-    #     for _ in range(10):
-    #         time.sleep(1)
-    #         bar.update(1)
+    # - Package/plugin handle already taken. [handled; asks user for new]
+    # - Version handle already deployed. [handled; asks user for new]
+    # - Bad parameter configuration. [mitigated by deriving template from Config object]
+    # - Package content fails health check (ex. bad import) [Error caught while checking config object]
 
 
 cli.add_command(deploy)

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -1,26 +1,62 @@
 import sys
+import time
+from os import path
+
+import click
 
 from steamship import Steamship
 from steamship.base.configuration import Configuration
+from steamship.cli.manifest_init_wizard import manifest_init_wizard
 from steamship.data.user import User
 
 
+@click.group()
 def cli():
-    if len(sys.argv) != 2 or sys.argv[1] not in ["login", "deploy"]:
-        print("Only options are login or deploy.")
-        sys.exit(-1)
-    else:
-        print("Logging into Steamship.")
-        if sys.argv[1] == "login":
-            if Configuration.default_config_file_has_api_key():
-                response = input(
-                    "You already have an API key in your .steamship.json file.  Do you want to remove it and login? [y/n] "
-                )
-                if response.lower() != "y":
-                    sys.exit(0)
-                Configuration.remove_api_key_from_default_config()
+    pass
 
-            # Carry on with login
-            client = Steamship()
-            user = User.current(client)
-            print(f"🚢🚢🚢 Hooray! You're logged in with user handle: {user.handle} 🚢🚢🚢")
+
+@click.command()
+def login():
+    click.echo("Logging into Steamship.")
+    if sys.argv[1] == "login":
+        if Configuration.default_config_file_has_api_key():
+            overwrite = click.confirm(
+                text="You already have an API key in your .steamship.json file.  Do you want to remove it and login?",
+                default=False,
+            )
+            if not overwrite:
+                sys.exit(0)
+            Configuration.remove_api_key_from_default_config()
+
+        # Carry on with login
+        client = Steamship()
+        user = User.current(client)
+        click.echo(
+            click.style(
+                f"🚢🚢🚢 Hooray! You're logged in with user handle: {user.handle} 🚢🚢🚢", fg="green"
+            )
+        )
+
+
+@click.command()
+def deploy():
+    client = Steamship()
+    if not path.exists("steamship.json"):
+        manifest_init_wizard(client)
+
+    with click.progressbar(
+        length=10,
+        fill_char="🚢",
+        empty_char=" ",
+        show_eta=False,
+        show_percent=False,
+        show_pos=True,
+        label="Shipping your package",
+    ) as bar:
+        for _ in range(10):
+            time.sleep(1)
+            bar.update(1)
+
+
+cli.add_command(deploy)
+cli.add_command(login)

--- a/src/steamship/cli/deploy.py
+++ b/src/steamship/cli/deploy.py
@@ -126,7 +126,7 @@ class DeployableDeployer(ABC):
     def ask_for_new_handle(self, manifest: Manifest):
         try_again = click.confirm(
             click.style(
-                f"\nIt looks like that handle [{manifest.handle}]is already taken by another user.  Would you like to change the handle and try again?",
+                f"\nIt looks like that handle [{manifest.handle}] is already taken by another user.  Would you like to change the handle and try again?",
                 fg="yellow",
             ),
             default=True,

--- a/src/steamship/cli/deploy.py
+++ b/src/steamship/cli/deploy.py
@@ -1,0 +1,105 @@
+import importlib
+import os
+import zipfile
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+import click
+
+from steamship import Package, PackageVersion, Steamship, SteamshipError
+from steamship.invocable.lambda_handler import get_class_from_module
+from steamship.invocable.manifest import Manifest
+
+DEFAULT_BUILD_IGNORE = [
+    "build",
+    ".git",
+    ".venv",
+    ".ipynb_checkpoints",
+    ".DS_Store",
+    "venv",
+    "tests",
+    "examples",
+    ".idea",
+    "__pycache__",
+]
+
+
+def update_config_template(manifest: Manifest):
+
+    path = Path("src/api.py")
+    if not path.exists():
+        path = Path("api.py")
+        if not path.exists():
+            raise SteamshipError("Could not find api.py either in root directory or in src.")
+
+    module = importlib.machinery.SourceFileLoader("api", str(path)).load_module()
+    invocable_type = get_class_from_module(module)
+
+    # DK: why do I have to pass invocable_type here into config_cls class method?
+    config_parameters = invocable_type.config_cls(invocable_type).get_config_parameters()
+
+    if len(config_parameters) > 0:
+        click.echo(
+            click.style(
+                "Found the following config parameters; updating steamship.json.", fg="cyan"
+            )
+        )
+        for param_name, param in config_parameters.items():
+            click.echo(f"{param_name}:")
+            click.echo(f"\tType: {param.type}")
+            click.echo(f"\tDefault: {param.default}")
+            click.echo(f"\tDescription: {param.description}")
+    else:
+        click.echo(click.style("Found no config parameters; updating steamship.json.", fg="cyan"))
+
+    manifest.configTemplate = config_parameters
+    manifest.save()
+
+
+def bundle_deployable(manifest: Manifest):
+    archive_path = Path(".") / "build" / "archives" / f"{manifest.handle}_v{manifest.version}.zip"
+    excludes = DEFAULT_BUILD_IGNORE + manifest.build_config.get("ignore", [])
+
+    archive_path.unlink(missing_ok=True)
+    with zipfile.ZipFile(
+        file=archive_path, mode="a", compression=zipfile.ZIP_DEFLATED, allowZip64=False
+    ) as zip_file:
+
+        root = Path(".")
+        for file_path in root.iterdir():
+            if file_path.name not in excludes:
+                if file_path.is_dir():
+                    for directory, _, files in os.walk(file_path):
+                        subdirectory_path = Path(directory)
+                        if Path(directory).name not in excludes:
+                            for file in files:
+                                pypi_file = subdirectory_path / file
+                                relative_to = pypi_file.relative_to(file_path)
+                                zip_file.write(pypi_file, relative_to)
+
+                else:
+                    zip_file.write(file_path)
+
+
+class DeployableDeployer(ABC):
+    @abstractmethod
+    def create_version(self, client: Steamship, manifest: Manifest, thing_id: str):
+        pass
+
+    @abstractmethod
+    def create_object(self, client: Steamship, manifest: Manifest):
+        pass
+
+
+class PackageDeployer(DeployableDeployer):
+    def create_version(self, client: Steamship, manifest: Manifest, thing_id: str):
+        return PackageVersion.create(
+            client=client,
+            config_template=manifest.config_template_as_dict(),
+            handle=manifest.version,
+            filename=f"build/archives/{manifest.handle}_v{manifest.version}.zip",
+            package_id=thing_id,
+        )
+
+    def create_object(self, client: Steamship, manifest: Manifest):
+        return Package.create(client, handle=manifest.handle, fetch_if_exists=True)

--- a/src/steamship/cli/deploy.py
+++ b/src/steamship/cli/deploy.py
@@ -111,44 +111,44 @@ class DeployableDeployer(ABC):
         pass
 
     @abstractmethod
-    def thing_type(self):
+    def deployable_type(self):
         pass
 
-    def create_or_fetch_thing(self, client: Steamship, user: User, manifest: Manifest):
-        thing = None
-        while thing is None:
+    def create_or_fetch_deployable(self, client: Steamship, user: User, manifest: Manifest):
+        deployable = None
+        while deployable is None:
             click.echo(
-                f"Creating / fetching {self.thing_type()} with handle [{manifest.handle}]... ",
+                f"Creating / fetching {self.deployable_type()} with handle [{manifest.handle}]... ",
                 nl=False,
             )
             try:
-                thing = self.create_object(client, manifest)
-                if thing.user_id != user.id:
+                deployable = self.create_object(client, manifest)
+                if deployable.user_id != user.id:
                     self.ask_for_new_handle(manifest)
-                    thing = None
+                    deployable = None
             except SteamshipError as e:
                 if e.message == "Something went wrong.":
                     self.ask_for_new_handle(manifest)
                 else:
                     click.secho(
-                        f"Unable to create / fetch {self.thing_type()}. Server returned message: {e.message}"
+                        f"Unable to create / fetch {self.deployable_type()}. Server returned message: {e.message}"
                     )
                     click.get_current_context().abort()
 
         click.echo("Done.")
-        return thing
+        return deployable
 
     def ask_for_new_handle(self, manifest: Manifest):
         try_again = click.confirm(
             click.style(
-                f"\nIt looks like that handle [{manifest.handle}] is already taken by another user.  Would you like to change the handle and try again?",
+                f"\nIt looks like that handle [{manifest.handle}] is already in use. Would you like to change the handle and try again?",
                 fg="yellow",
             ),
             default=True,
         )
         if try_again:
             new_handle = click.prompt(
-                f"What handle would you like to use for your {self.thing_type()}? Valid characters are a-z and -",
+                f"What handle would you like to use for your {self.deployable_type()}? Valid characters are a-z and -",
                 value_proc=validate_handle,
             )
             manifest.handle = new_handle
@@ -168,7 +168,7 @@ class DeployableDeployer(ABC):
                     self.ask_for_new_version_handle(manifest)
                 else:
                     click.secho(
-                        f"Unable to create / fetch {self.thing_type()}. Server returned message: {e.message}"
+                        f"Unable to create / fetch {self.deployable_type()}. Server returned message: {e.message}"
                     )
                     click.get_current_context().abort()
         click.echo("\nDone. 🚢")
@@ -214,5 +214,5 @@ class PackageDeployer(DeployableDeployer):
     def create_object(self, client: Steamship, manifest: Manifest):
         return Package.create(client, handle=manifest.handle, fetch_if_exists=True)
 
-    def thing_type(self):
+    def deployable_type(self):
         return "package"

--- a/src/steamship/cli/deploy.py
+++ b/src/steamship/cli/deploy.py
@@ -5,8 +5,12 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 
 import click
+from semver import VersionInfo
 
 from steamship import Package, PackageVersion, Steamship, SteamshipError
+from steamship.cli.manifest_init_wizard import validate_handle, validate_version_handle
+from steamship.cli.ship_spinner import ship_spinner
+from steamship.data.user import User
 from steamship.invocable.lambda_handler import get_class_from_module
 from steamship.invocable.manifest import Manifest
 
@@ -39,25 +43,25 @@ def update_config_template(manifest: Manifest):
     config_parameters = invocable_type.config_cls(invocable_type).get_config_parameters()
 
     if len(config_parameters) > 0:
-        click.echo(
-            click.style(
-                "Found the following config parameters; updating steamship.json.", fg="cyan"
-            )
-        )
+        click.secho("Found the following config parameters; updating steamship.json.", fg="cyan")
         for param_name, param in config_parameters.items():
             click.echo(f"{param_name}:")
             click.echo(f"\tType: {param.type}")
             click.echo(f"\tDefault: {param.default}")
             click.echo(f"\tDescription: {param.description}")
     else:
-        click.echo(click.style("Found no config parameters; updating steamship.json.", fg="cyan"))
+        click.secho("Found no config parameters; updating steamship.json.", fg="cyan")
 
     manifest.configTemplate = config_parameters
     manifest.save()
 
 
+def get_archive_path(manifest: Manifest) -> Path:
+    return Path(".") / "build" / "archives" / f"{manifest.handle}_v{manifest.version}.zip"
+
+
 def bundle_deployable(manifest: Manifest):
-    archive_path = Path(".") / "build" / "archives" / f"{manifest.handle}_v{manifest.version}.zip"
+    archive_path = get_archive_path(manifest)
     excludes = DEFAULT_BUILD_IGNORE + manifest.build_config.get("ignore", [])
 
     archive_path.unlink(missing_ok=True)
@@ -83,16 +87,105 @@ def bundle_deployable(manifest: Manifest):
 
 class DeployableDeployer(ABC):
     @abstractmethod
-    def create_version(self, client: Steamship, manifest: Manifest, thing_id: str):
+    def _create_version(self, client: Steamship, manifest: Manifest, thing_id: str):
         pass
 
     @abstractmethod
     def create_object(self, client: Steamship, manifest: Manifest):
         pass
 
+    @abstractmethod
+    def thing_type(self):
+        pass
+
+    def create_or_fetch_thing(self, client: Steamship, user: User, manifest: Manifest):
+        thing = None
+        while thing is None:
+            click.echo(
+                f"Creating / fetching {self.thing_type()} with handle [{manifest.handle}]... ",
+                nl=False,
+            )
+            try:
+                thing = self.create_object(client, manifest)
+                print(f"Userid: {thing.user_id}")
+                if thing.user_id != user.id:
+                    self.ask_for_new_handle(manifest)
+                    thing = None
+            except SteamshipError as e:
+                if e.message == "Something went wrong.":
+                    self.ask_for_new_handle(manifest)
+                else:
+                    click.secho(
+                        f"Unable to create / fetch {self.thing_type()}. Server returned message: {e.message}"
+                    )
+                    click.get_current_context().abort()
+
+        click.echo("Done.")
+        return thing
+
+    def ask_for_new_handle(self, manifest: Manifest):
+        try_again = click.confirm(
+            click.style(
+                f"\nIt looks like that handle [{manifest.handle}]is already taken by another user.  Would you like to change the handle and try again?",
+                fg="yellow",
+            ),
+            default=True,
+        )
+        if try_again:
+            new_handle = click.prompt(
+                f"What handle would you like to use for your {self.thing_type()}? Valid characters are a-z and -",
+                value_proc=validate_handle,
+            )
+            manifest.handle = new_handle
+            manifest.save()
+        else:
+            click.get_current_context().abort()
+
+    def create_version(self, client: Steamship, manifest: Manifest, thing_id: str):
+        version = None
+        while version is None:
+            try:
+                with ship_spinner():
+                    version = self._create_version(client, manifest, thing_id)
+            except SteamshipError as e:
+                if e.message == "The object you are trying to create already exists.":
+                    self.ask_for_new_version_handle(manifest)
+                else:
+                    click.secho(
+                        f"Unable to create / fetch {self.thing_type()}. Server returned message: {e.message}"
+                    )
+                    click.get_current_context().abort()
+
+    def ask_for_new_version_handle(self, manifest: Manifest):
+        try_again = click.confirm(
+            click.style(
+                f"\nIt looks like that version [{manifest.version}] has already been deployed. Would you like to change the version handle and try again?",
+                fg="yellow",
+            ),
+            default=True,
+        )
+        if try_again:
+            default_new = "1.0.0"
+            try:
+                default_new = str(VersionInfo.parse(manifest.version).bump_prerelease())
+            except ValueError:
+                pass
+            old_archive_path = get_archive_path(manifest)
+            new_version_handle = click.prompt(
+                "What should the new version be? Valid characters are a-z, 0-9, . and -",
+                value_proc=validate_version_handle,
+                default=default_new,
+            )
+            manifest.version = new_version_handle
+            manifest.save()
+            new_archive_path = get_archive_path(manifest)
+            old_archive_path.rename(new_archive_path)
+        else:
+            click.get_current_context().abort()
+
 
 class PackageDeployer(DeployableDeployer):
-    def create_version(self, client: Steamship, manifest: Manifest, thing_id: str):
+    def _create_version(self, client: Steamship, manifest: Manifest, thing_id: str):
         return PackageVersion.create(
             client=client,
             config_template=manifest.config_template_as_dict(),
@@ -103,3 +196,6 @@ class PackageDeployer(DeployableDeployer):
 
     def create_object(self, client: Steamship, manifest: Manifest):
         return Package.create(client, handle=manifest.handle, fetch_if_exists=True)
+
+    def thing_type(self):
+        return "package"

--- a/src/steamship/cli/deploy.py
+++ b/src/steamship/cli/deploy.py
@@ -50,8 +50,7 @@ def update_config_template(manifest: Manifest):
 
     invocable_type = get_class_from_module(module)
 
-    # DK: why do I have to pass invocable_type here into config_cls class method?
-    config_parameters = invocable_type.config_cls(invocable_type).get_config_parameters()
+    config_parameters = invocable_type.config_cls().get_config_parameters()
 
     if manifest.configTemplate != config_parameters:
         if len(config_parameters) > 0:
@@ -74,6 +73,7 @@ def get_archive_path(manifest: Manifest) -> Path:
 
 def bundle_deployable(manifest: Manifest):
     archive_path = get_archive_path(manifest)
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
     excludes = DEFAULT_BUILD_IGNORE + manifest.build_config.get("ignore", [])
 
     archive_path.unlink(missing_ok=True)

--- a/src/steamship/cli/login.py
+++ b/src/steamship/cli/login.py
@@ -36,17 +36,17 @@ def login(api_base: str, web_base: str) -> str:  # noqa: C901
         )
 
     # Wait on result
-    total_poll_time = 0
-    time_between_polls = 1
+    total_poll_time_s = 0
+    time_between_polls_s = 1
     api_key = None
-    while total_poll_time < 300:  # Five minutes
+    while total_poll_time_s < 300:  # Five minutes
         params = {"token": token}
         login_response = requests.post(f"{api_base}account/poll_login_attempt", json=params).json()
         if login_response.get("data", {}).get("status") == "done":
             api_key = login_response.get("data", {}).get("apiKey")
             break
-        time.sleep(time_between_polls)
-        total_poll_time += time_between_polls
+        time.sleep(time_between_polls_s)
+        total_poll_time_s += time_between_polls_s
 
     if api_key is None:
         raise SteamshipError("Could not fetch api key after login attempt in allotted time.")

--- a/src/steamship/cli/login.py
+++ b/src/steamship/cli/login.py
@@ -1,0 +1,54 @@
+import time
+import webbrowser
+
+import requests
+
+from steamship.base.error import SteamshipError
+
+
+def login(api_base: str, web_base: str) -> str:  # noqa: C901
+
+    # create login token
+    try:
+        token_result = requests.post(api_base + "account/create_login_attempt")
+        token_data = token_result.json().get("data")
+    except Exception as e:
+        raise SteamshipError("Could not create login token when attempting login.", error=e)
+
+    if token_data is None:
+        raise SteamshipError("Could not create login token when attempting login.")
+    token = token_data.get("token")
+    if token is None:
+        raise SteamshipError("Could not create login token when attempting login.")
+
+    # Launch login attempt in browser
+    login_browser_url = (
+        f"{web_base}account/client-login?attemptToken={token}&client=pycli&version=0.0.1"
+    )
+    try:
+        opened_browser = webbrowser.open(login_browser_url)
+    except Exception as e:
+        raise SteamshipError("Exception attempting to launch browser for login.", error=e)
+
+    if not opened_browser:
+        raise SteamshipError(
+            "Could not launch browser for login flow. If you are in Replit or another headless environment, please set your Steamship API key as an environment variable or in steamship.json.  See more here: https://docs.steamship.com/configuration/authentication.html"
+        )
+
+    # Wait on result
+    total_poll_time = 0
+    time_between_polls = 1
+    api_key = None
+    while total_poll_time < 300:  # Five minutes
+        params = {"token": token}
+        login_response = requests.post(f"{api_base}account/poll_login_attempt", json=params).json()
+        if login_response.get("data", {}).get("status") == "done":
+            api_key = login_response.get("data", {}).get("apiKey")
+            break
+        time.sleep(time_between_polls)
+        total_poll_time += time_between_polls
+
+    if api_key is None:
+        raise SteamshipError("Could not fetch api key after login attempt in allotted time.")
+
+    return api_key

--- a/src/steamship/cli/manifest_init_wizard.py
+++ b/src/steamship/cli/manifest_init_wizard.py
@@ -1,0 +1,84 @@
+import re
+
+import click
+from click import BadParameter
+
+from steamship import Steamship
+from steamship.data.user import User
+
+
+def validate_handle(handle: str) -> str:
+    if re.fullmatch(r"[a-z\-]+", handle) is not None:
+        return handle
+    else:
+        raise BadParameter("Handle must only include lowercase letters and -")
+
+
+def manifest_init_wizard(client: Steamship):
+    click.echo(
+        click.style(
+            "It looks like you don't yet have a steamship.json to deploy. Let's create one.",
+            fg="cyan",
+        )
+    )
+
+    deployable_type = click.prompt(
+        "Is this a package or a plugin?",
+        default="package",
+        type=click.Choice(["package", "plugin"]),
+        show_choices=False,
+    )
+
+    handle = click.prompt(
+        f"What handle would you like to use for your {deployable_type}? Valid characters are a-z and -",
+        value_proc=validate_handle,
+    )
+
+    # TODO: claim the handle right here!
+
+    version_handle = "0.0.1"
+
+    public = click.confirm(f"Do you want this {deployable_type} to be public?", default=True)
+
+    user = User.current(client)
+
+    author = click.prompt("How should we list your author name?", default=user.handle)
+
+    # TODO: Config variables
+
+    tagline = None
+    author_github = None
+    if public:
+        tagline = click.prompt(f"Want to give the {deployable_type} a tagline?", default="")
+        author_github = click.prompt(
+            "If you'd like this associated with your github account, please enter it", default=""
+        )
+
+    manifest = {
+        "type": deployable_type,
+        "handle": handle,
+        "version": version_handle,
+        "description": "",
+        "author": author,
+        "entrypoint": "api.handler",
+        "public": public,
+        "build_config": {"ignore": ["tests", "examples"]},
+        "configTemplate": {},
+        "steamshipRegistry": {
+            "tagline": tagline,
+            "tagline2": None,
+            "usefulFor": None,
+            "videoUrl": None,
+            "githubUrl": None,
+            "demoUrl": None,
+            "blogUrl": None,
+            "jupyterUrl": None,
+            "authorGithub": author_github,
+            "authorName": author,
+            "authorEmail": None,
+            "authorTwitter": None,
+            "authorUrl": None,
+            "tags": [],
+        },
+    }
+    print(manifest)

--- a/src/steamship/cli/manifest_init_wizard.py
+++ b/src/steamship/cli/manifest_init_wizard.py
@@ -55,7 +55,8 @@ def manifest_init_wizard(client: Steamship):
     if public:
         tagline = click.prompt(f"Want to give the {deployable_type} a tagline?", default="")
         author_github = click.prompt(
-            "If you'd like this associated with your github account, please enter it", default=""
+            "If you'd like this associated with your github account, please your github username",
+            default="",
         )
 
     return Manifest(

--- a/src/steamship/cli/manifest_init_wizard.py
+++ b/src/steamship/cli/manifest_init_wizard.py
@@ -15,12 +15,17 @@ def validate_handle(handle: str) -> str:
         raise BadParameter("Handle must only include lowercase letters and -")
 
 
+def validate_version_handle(handle: str) -> str:
+    if re.fullmatch(r"[a-z0-9\-.]+", handle) is not None:
+        return handle
+    else:
+        raise BadParameter("Handle must only include lowercase letters, numbers, . and -")
+
+
 def manifest_init_wizard(client: Steamship):
-    click.echo(
-        click.style(
-            "It looks like you don't yet have a steamship.json to deploy. Let's create one.",
-            fg="cyan",
-        )
+    click.secho(
+        "It looks like you don't yet have a steamship.json to deploy. Let's create one.",
+        fg="cyan",
     )
 
     deployable_type = click.prompt(

--- a/src/steamship/cli/manifest_init_wizard.py
+++ b/src/steamship/cli/manifest_init_wizard.py
@@ -5,6 +5,7 @@ from click import BadParameter
 
 from steamship import Steamship
 from steamship.data.user import User
+from steamship.invocable.manifest import Manifest, SteamshipRegistry
 
 
 def validate_handle(handle: str) -> str:
@@ -44,8 +45,6 @@ def manifest_init_wizard(client: Steamship):
 
     author = click.prompt("How should we list your author name?", default=user.handle)
 
-    # TODO: Config variables
-
     tagline = None
     author_github = None
     if public:
@@ -54,31 +53,15 @@ def manifest_init_wizard(client: Steamship):
             "If you'd like this associated with your github account, please enter it", default=""
         )
 
-    manifest = {
-        "type": deployable_type,
-        "handle": handle,
-        "version": version_handle,
-        "description": "",
-        "author": author,
-        "entrypoint": "api.handler",
-        "public": public,
-        "build_config": {"ignore": ["tests", "examples"]},
-        "configTemplate": {},
-        "steamshipRegistry": {
-            "tagline": tagline,
-            "tagline2": None,
-            "usefulFor": None,
-            "videoUrl": None,
-            "githubUrl": None,
-            "demoUrl": None,
-            "blogUrl": None,
-            "jupyterUrl": None,
-            "authorGithub": author_github,
-            "authorName": author,
-            "authorEmail": None,
-            "authorTwitter": None,
-            "authorUrl": None,
-            "tags": [],
-        },
-    }
-    print(manifest)
+    return Manifest(
+        type=deployable_type,
+        handle=handle,
+        version=version_handle,
+        author=author,
+        public=public,
+        build_config={"ignore": ["tests", "examples"]},
+        configTemplate={},
+        steamshipRegistry=SteamshipRegistry(
+            tagline=tagline, authorGithub=author_github, authorName=author, tags=[]
+        ),
+    )

--- a/src/steamship/cli/ship_spinner.py
+++ b/src/steamship/cli/ship_spinner.py
@@ -1,23 +1,23 @@
 import itertools
-import sys
 import threading
 
 import click
 
 
 class Spinner(object):
-    spinner_cycle = itertools.cycle(["   🚢", "  🚢 ", " 🚢  ", "🚢   "])
+    # ["   🚢", "  🚢 ", " 🚢  ", "🚢   "]
+    # Unfortunately, backspacing doesn't seem to work correctly for emoji in iTerm, so leaving the "spinner"
+    # as adding ships for now
+    spinner_cycle = itertools.cycle(["🚢"])
 
-    def __init__(self, stream=sys.stdout):
-        self.stream = stream
+    def __init__(self):
         self.stop_running = None
         self.spin_thread = None
 
     def start(self):
-        if self.stream.isatty():
-            self.stop_running = threading.Event()
-            self.spin_thread = threading.Thread(target=self.init_spin)
-            self.spin_thread.start()
+        self.stop_running = threading.Event()
+        self.spin_thread = threading.Thread(target=self.init_spin)
+        self.spin_thread.start()
 
     def stop(self):
         if self.spin_thread:
@@ -27,8 +27,8 @@ class Spinner(object):
     def init_spin(self):
         while not self.stop_running.is_set():
             click.echo(next(self.spinner_cycle), nl=False)
-            self.stop_running.wait(0.25)
-            click.echo("\b\b\b\b", nl=False)
+            self.stop_running.wait(1)
+            # click.echo("\b", nl=False)
 
     def __enter__(self):
         self.start()
@@ -39,10 +39,10 @@ class Spinner(object):
         return False
 
 
-def ship_spinner(beep=False, disable=False, force=False, stream=sys.stdout):
+def ship_spinner():
     """This function creates a context manager that is used to display a
     spinner on stdout as long as the context has not exited.
     The spinner is created only if stdout is not redirected, or if the spinner
     is forced using the `force` parameter.
     """
-    return Spinner(stream)
+    return Spinner()

--- a/src/steamship/cli/ship_spinner.py
+++ b/src/steamship/cli/ship_spinner.py
@@ -2,6 +2,8 @@ import itertools
 import sys
 import threading
 
+import click
+
 
 class Spinner(object):
     spinner_cycle = itertools.cycle(["   🚢", "  🚢 ", " 🚢  ", "🚢   "])
@@ -24,11 +26,9 @@ class Spinner(object):
 
     def init_spin(self):
         while not self.stop_running.is_set():
-            self.stream.write(next(self.spinner_cycle))
-            self.stream.flush()
+            click.echo(next(self.spinner_cycle), nl=False)
             self.stop_running.wait(0.25)
-            self.stream.write("\b\b\b\b")
-            self.stream.flush()
+            click.echo("\b\b\b\b", nl=False)
 
     def __enter__(self):
         self.start()

--- a/src/steamship/cli/ship_spinner.py
+++ b/src/steamship/cli/ship_spinner.py
@@ -1,0 +1,48 @@
+import itertools
+import sys
+import threading
+
+
+class Spinner(object):
+    spinner_cycle = itertools.cycle(["   🚢", "  🚢 ", " 🚢  ", "🚢   "])
+
+    def __init__(self, stream=sys.stdout):
+        self.stream = stream
+        self.stop_running = None
+        self.spin_thread = None
+
+    def start(self):
+        if self.stream.isatty():
+            self.stop_running = threading.Event()
+            self.spin_thread = threading.Thread(target=self.init_spin)
+            self.spin_thread.start()
+
+    def stop(self):
+        if self.spin_thread:
+            self.stop_running.set()
+            self.spin_thread.join()
+
+    def init_spin(self):
+        while not self.stop_running.is_set():
+            self.stream.write(next(self.spinner_cycle))
+            self.stream.flush()
+            self.stop_running.wait(0.25)
+            self.stream.write("\b\b\b\b")
+            self.stream.flush()
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+        return False
+
+
+def ship_spinner(beep=False, disable=False, force=False, stream=sys.stdout):
+    """This function creates a context manager that is used to display a
+    spinner on stdout as long as the context has not exited.
+    The spinner is created only if stdout is not redirected, or if the spinner
+    is forced using the `force` parameter.
+    """
+    return Spinner(stream)

--- a/src/steamship/data/package/package.py
+++ b/src/steamship/data/package/package.py
@@ -14,6 +14,10 @@ from steamship.base.client import Client
 from steamship.base.request import CreateRequest, GetRequest
 
 
+class PackageCreateRequest(CreateRequest):
+    fetch_if_exists = False
+
+
 class Package(BaseModel):
     client: Client = Field(None, exclude=True)
     id: str = None
@@ -26,8 +30,8 @@ class Package(BaseModel):
         return super().parse_obj(obj)
 
     @staticmethod
-    def create(client: Client, handle: str = None) -> Package:
-        req = CreateRequest(handle=handle)
+    def create(client: Client, handle: str = None, fetch_if_exists=False) -> Package:
+        req = PackageCreateRequest(handle=handle, fetch_if_exists=fetch_if_exists)
         return client.post("package/create", payload=req, expect=Package)
 
     @staticmethod

--- a/src/steamship/data/package/package.py
+++ b/src/steamship/data/package/package.py
@@ -11,6 +11,7 @@ from typing import Any, Type
 from pydantic import BaseModel, Field
 
 from steamship.base.client import Client
+from steamship.base.model import CamelModel
 from steamship.base.request import CreateRequest, GetRequest
 
 
@@ -18,10 +19,11 @@ class PackageCreateRequest(CreateRequest):
     fetch_if_exists = False
 
 
-class Package(BaseModel):
+class Package(CamelModel):
     client: Client = Field(None, exclude=True)
     id: str = None
     handle: str = None
+    user_id: str = None
 
     @classmethod
     def parse_obj(cls: Type[BaseModel], obj: Any) -> BaseModel:

--- a/src/steamship/invocable/config.py
+++ b/src/steamship/invocable/config.py
@@ -1,8 +1,51 @@
 import json
+from enum import Enum
 from pathlib import Path
+from typing import List, Optional, Type, Union
 
 from steamship import SteamshipError
 from steamship.base.model import CamelModel
+
+
+class ConfigParameterType(str, Enum):
+    NUMBER = "number"
+    STRING = "string"
+    BOOLEAN = "boolean"
+
+    @staticmethod
+    def from_python_type(t: Type):
+        if issubclass(t, str):
+            return ConfigParameterType.STRING
+        elif issubclass(t, bool):  # bool is a subclass of int, so must do this first!
+            return ConfigParameterType.BOOLEAN
+        elif issubclass(t, float) or issubclass(t, int):
+            return ConfigParameterType.NUMBER
+        else:
+            raise SteamshipError(f"Unknown value type in Config: {t}")
+
+    @staticmethod
+    def parse_default_value(default_value: str, t: Type):
+        if default_value is None:
+            return None
+        elif issubclass(t, str):
+            return default_value
+        elif issubclass(t, bool):  # bool is a subclass of int, so must do this first!
+            return default_value == "True"
+        elif issubclass(t, int):
+            return int(default_value)
+        elif issubclass(t, float):
+            return float(default_value)
+        else:
+            raise SteamshipError(f"Unknown value type in Config: {t}")
+
+
+class ConfigParameter(CamelModel):
+    name: str
+    type_: ConfigParameterType
+    description: Optional[str] = None
+
+    # Note order is important here in the union; Pydantic will coerce values into the first union type that fits!
+    default: Optional[Union[bool, float, str]] = None
 
 
 class Config(CamelModel):
@@ -38,3 +81,22 @@ class Config(CamelModel):
                     message=f"Attempted to extend Config object with {path}, but the file did not contain a JSON `dict` object."
                 )
             self.extend_with_dict(data, overwrite)
+
+    def get_config_parameters(self) -> List[ConfigParameter]:
+        result = []
+        for field_name, field in self.__fields__.items():
+            description = self.get_description_for_field(field_name)
+            type_ = ConfigParameterType.from_python_type(field.type_)
+            result.append(
+                ConfigParameter(
+                    name=field_name,
+                    type_=type_,
+                    default=field.default,  # ConfigParameterType.parse_default_value(field.default, field.type_),
+                    description=description,
+                )
+            )
+
+        return result
+
+    def get_description_for_field(self, field_name: str):
+        return "Todo: usefully extract descriptions"

--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -7,13 +7,14 @@ from abc import ABC
 from collections import defaultdict
 from functools import wraps
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union
 
 import toml
 
 from steamship.base.package_spec import MethodSpec, PackageSpec
 from steamship.client import Steamship
 from steamship.invocable import Config
+from steamship.invocable.config import ConfigParameter
 from steamship.invocable.invocable_request import InvocableRequest, InvocationContext
 from steamship.invocable.invocable_response import InvocableResponse
 from steamship.utils.url import Verb
@@ -255,3 +256,6 @@ class Invocable(ABC):
             return getattr(self, method)()
         else:
             return getattr(self, method)(**arguments)
+
+    def get_config_parameters(self) -> List[ConfigParameter]:
+        return self.config.get_config_parameters()

--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -185,9 +185,10 @@ class Invocable(ABC):
             class MyConfig(Config):
                 ...
 
-            def config_cls(self):
+            @classmethod
+            def config_cls(cls):
                 return MyPackageOrPlugin.MyConfig
-        """
+        """  # noqa: RST301
         return Config
 
     @classmethod
@@ -260,5 +261,4 @@ class Invocable(ABC):
 
     @classmethod
     def get_config_parameters(cls) -> Dict[str, ConfigParameter]:
-        # DK: why do I need to pass cls to config_cls here?  If I don't pass it, it throws an error.
-        return cls.config_cls(cls).get_config_parameters()
+        return cls.config_cls().get_config_parameters()

--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -7,7 +7,7 @@ from abc import ABC
 from collections import defaultdict
 from functools import wraps
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, Optional, Type, Union
 
 import toml
 
@@ -174,7 +174,8 @@ class Invocable(ABC):
         """Return this Invocable's PackageSpec for remote inspection -- e.g. documentation or OpenAPI generation."""
         return self._package_spec.dict()
 
-    def config_cls(self) -> Type[Config]:
+    @classmethod
+    def config_cls(cls) -> Type[Config]:
         """Returns the configuration object for the Invocable.
 
         By default, Steamship packages and plugins will not take any configuration. Steamship packages and plugins may
@@ -257,5 +258,7 @@ class Invocable(ABC):
         else:
             return getattr(self, method)(**arguments)
 
-    def get_config_parameters(self) -> List[ConfigParameter]:
-        return self.config.get_config_parameters()
+    @classmethod
+    def get_config_parameters(cls) -> Dict[str, ConfigParameter]:
+        # DK: why do I need to pass cls to config_cls here?  If I don't pass it, it throws an error.
+        return cls.config_cls(cls).get_config_parameters()

--- a/src/steamship/invocable/lambda_handler.py
+++ b/src/steamship/invocable/lambda_handler.py
@@ -1,3 +1,4 @@
+import importlib
 import inspect
 import json
 import logging
@@ -270,7 +271,8 @@ def safely_find_invocable_class() -> Type[Invocable]:
     Safely find the invocable class within invocable code.
     """
     try:
-        import api
+        module = importlib.import_module("api")
+        return get_class_from_module(module)
     except Exception as e:
         logging.exception(e)
         raise SteamshipError(
@@ -278,8 +280,10 @@ def safely_find_invocable_class() -> Type[Invocable]:
             error=e,
         )
 
+
+def get_class_from_module(module) -> Type[Invocable]:
     invocable_classes = []
-    for element in [getattr(api, x) for x in dir(api)]:
+    for element in [getattr(module, x) for x in dir(module)]:
         if inspect.isclass(element):
             # Using names and not issubclass(element, Invocable) because latter was returning false?
             superclass_names = [c.__name__ for c in inspect.getmro(element)]

--- a/src/steamship/invocable/manifest.py
+++ b/src/steamship/invocable/manifest.py
@@ -1,0 +1,56 @@
+import json
+from enum import Enum
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
+from steamship.invocable.config import ConfigParameter
+
+
+class DeployableType(str, Enum):
+    PLUGIN = "plugin"
+    PACKAGE = "package"
+
+
+class SteamshipRegistry(BaseModel):
+    tagline: Optional[str]  # noqa: N815
+    tagline2: Optional[str]  # noqa: N815
+    usefulFor: Optional[str]  # noqa: N815
+    videoURL: Optional[str]  # noqa: N815
+    githubURL: Optional[str]  # noqa: N815
+    demoURL: Optional[str]  # noqa: N815
+    jupyterURL: Optional[str]  # noqa: N815
+    authorGithub: Optional[str]  # noqa: N815
+    authorName: Optional[str]  # noqa: N815
+    authorEmail: Optional[str]  # noqa: N815
+    authorTwitter: Optional[str]  # noqa: N815
+    authorURL: Optional[str]  # noqa: N815
+    tags: List[str]
+
+
+class Manifest(BaseModel):
+    type: DeployableType
+    handle: str
+    version: str
+    description: Optional[str]
+    author: Optional[str]
+    entrypoint: str = "Unused"
+    public: bool
+    build_config: Dict[str, List[str]] = {"ignore": []}
+    configTemplate: Dict[str, ConfigParameter]  # noqa: N815
+    steamshipRegistry: SteamshipRegistry  # noqa: N815
+
+    @staticmethod
+    def load_manifest() -> "Manifest":
+        return Manifest.parse_file("steamship.json", content_type="application/json")
+
+    def save(self):
+        with open("steamship.json", "w") as file:
+            json.dump(self.dict(), file, indent="\t")
+
+    def config_template_as_dict(self):
+        result = {}
+        for param, spec in self.configTemplate.items():
+            result[param] = {k: v for k, v in spec.dict().items() if v is not None}
+
+        return result

--- a/tests/assets/packages/configurable_hello_world.py
+++ b/tests/assets/packages/configurable_hello_world.py
@@ -7,7 +7,10 @@ class HelloWorld(Invocable):
     # Package configuration is always defined by a Pydantic object which derives from
     # the base `Config` object.
     class HelloWorldConfig(Config):
+        """The configuration class for configurable Hello World"""
+
         greeting: str
+        """ The greeting to greet with """
 
         # The casing of config variables is preserved exactly as the Steamship package author defines them.
         # Snake case is permitted

--- a/tests/assets/packages/configurable_hello_world.py
+++ b/tests/assets/packages/configurable_hello_world.py
@@ -41,8 +41,9 @@ class HelloWorld(Invocable):
     def defaulted(self) -> InvocableResponse:
         return InvocableResponse(string=self.config.defaultConfig)
 
-    def config_cls(self) -> Type[Config]:
-        return self.HelloWorldConfig
+    @classmethod
+    def config_cls(cls) -> Type[Config]:
+        return cls.HelloWorldConfig
 
 
 handler = create_handler(HelloWorld)

--- a/tests/assets/plugins/blockifiers/blockifier.py
+++ b/tests/assets/plugins/blockifiers/blockifier.py
@@ -23,8 +23,9 @@ class DummyBlockifierPlugin(Blockifier):
     class DummyBlockifierConfig(Config):
         pass
 
-    def config_cls(self) -> Type[Config]:
-        return self.DummyBlockifierConfig
+    @classmethod
+    def config_cls(cls) -> Type[Config]:
+        return cls.DummyBlockifierConfig
 
     def run(
         self, request: PluginRequest[RawDataPluginInput]

--- a/tests/assets/plugins/blockifiers/csv_blockifier.py
+++ b/tests/assets/plugins/blockifiers/csv_blockifier.py
@@ -41,8 +41,9 @@ class CsvBlockifier(Blockifier):
                 kwargs["tag_columns"] = kwargs["tag_columns"].split(",")
             super().__init__(**kwargs)
 
-    def config_cls(self) -> Type[CsvBlockifierConfig]:
-        return self.CsvBlockifierConfig
+    @classmethod
+    def config_cls(cls) -> Type[CsvBlockifierConfig]:
+        return cls.CsvBlockifierConfig
 
     def _get_text(self, row) -> str:
         text = row.get(self.config.text_column)

--- a/tests/assets/plugins/taggers/plugin_configurable_tagger.py
+++ b/tests/assets/plugins/taggers/plugin_configurable_tagger.py
@@ -24,8 +24,9 @@ class TestParserPlugin(Tagger):
 
     config: TestParserConfig
 
-    def config_cls(self) -> Type[Config]:
-        return self.TestParserConfig
+    @classmethod
+    def config_cls(cls) -> Type[Config]:
+        return cls.TestParserConfig
 
     def run(
         self, request: PluginRequest[BlockAndTagPluginInput]

--- a/tests/assets/plugins/taggers/plugin_trainable_tagger.py
+++ b/tests/assets/plugins/taggers/plugin_trainable_tagger.py
@@ -129,7 +129,8 @@ class TestTrainableTaggerPlugin(TrainableTagger):
 
     """
 
-    def config_cls(self) -> Type[Config]:
+    @classmethod
+    def config_cls(cls) -> Type[Config]:
         return EmptyConfig
 
     def model_cls(self) -> Type[TestTrainableTaggerModel]:

--- a/tests/assets/plugins/taggers/plugin_trainable_tagger_config.py
+++ b/tests/assets/plugins/taggers/plugin_trainable_tagger_config.py
@@ -73,7 +73,8 @@ class TestTrainableTaggerConfigPlugin(TrainableTagger):
 
     """
 
-    def config_cls(self) -> Type[Config]:
+    @classmethod
+    def config_cls(cls) -> Type[Config]:
         return TestConfig
 
     def model_cls(self) -> Type[TestTrainableTaggerConfigModel]:

--- a/tests/steamship_tests/app/unit/test_config_template_extraction.py
+++ b/tests/steamship_tests/app/unit/test_config_template_extraction.py
@@ -1,26 +1,19 @@
 from typing import Optional
 
 from assets.packages.configurable_hello_world import HelloWorld
+from pydantic import Field
 
 from steamship.invocable.config import Config, ConfigParameterType
 
 
 def test_config_parameters():
-    package = HelloWorld(
-        config={
-            "greeting": "yo",
-            "snake_case_config": "hisss",
-            "camelCaseConfig": "spit!",
-            "defaultConfig": "default",
-        }
-    )
-    config_template = package.get_config_parameters()
+    config_template = HelloWorld.get_config_parameters()
     assert len(config_template) == 4
-    for config_param in config_template:
+    for config_param in config_template.values():
         assert config_param.default is None
         assert config_param.type_ == ConfigParameterType.STRING
 
-    names = [p.name for p in config_template]
+    names = config_template.keys()
     assert "greeting" in names
     assert "snake_case_config" in names
     assert "camelCaseConfig" in names
@@ -32,14 +25,13 @@ def test_config_parameter_numbers():
         x: float
         y: int
 
-    number_config = NumberConfig(x=3, y=4)
-    config_template = number_config.get_config_parameters()
+    config_template = NumberConfig.get_config_parameters()
     assert len(config_template) == 2
-    for config_param in config_template:
+    for config_param in config_template.values():
         assert config_param.default is None
         assert config_param.type_ == ConfigParameterType.NUMBER
 
-    names = [p.name for p in config_template]
+    names = config_template.keys()
     assert "x" in names
     assert "y" in names
 
@@ -52,11 +44,11 @@ def test_config_parameter_boolean():
     bool_config = BoolConfig(x=True, y=False)
     config_template = bool_config.get_config_parameters()
     assert len(config_template) == 2
-    for config_param in config_template:
+    for config_param in config_template.values():
         assert config_param.default is None
         assert config_param.type_ == ConfigParameterType.BOOLEAN
 
-    names = [p.name for p in config_template]
+    names = config_template.keys()
     assert "x" in names
     assert "y" in names
 
@@ -72,15 +64,14 @@ def test_config_parameter_with_defaults():
     config_template = defaults_config.get_config_parameters()
     assert len(config_template) == 4
 
-    parameters = {p.name: p for p in config_template}
-    assert parameters["w"].type_ == ConfigParameterType.STRING
-    assert parameters["w"].default == "deeeefault"
-    assert parameters["x"].type_ == ConfigParameterType.BOOLEAN
-    assert parameters["x"].default  # Assert that the default == True
-    assert parameters["y"].type_ == ConfigParameterType.NUMBER
-    assert parameters["y"].default == 3
-    assert parameters["z"].type_ == ConfigParameterType.NUMBER
-    assert parameters["z"].default == 7.5
+    assert config_template["w"].type_ == ConfigParameterType.STRING
+    assert config_template["w"].default == "deeeefault"
+    assert config_template["x"].type_ == ConfigParameterType.BOOLEAN
+    assert config_template["x"].default  # Assert that the default == True
+    assert config_template["y"].type_ == ConfigParameterType.NUMBER
+    assert config_template["y"].default == 3
+    assert config_template["z"].type_ == ConfigParameterType.NUMBER
+    assert config_template["z"].default == 7.5
 
 
 def test_optional_config_parameters():
@@ -98,21 +89,32 @@ def test_optional_config_parameters():
     config_template = defaults_config.get_config_parameters()
     assert len(config_template) == 8
 
-    parameters = {p.name: p for p in config_template}
-    assert parameters["w"].type_ == ConfigParameterType.STRING
-    assert parameters["w"].default == "deeeefault"
-    assert parameters["x"].type_ == ConfigParameterType.BOOLEAN
-    assert parameters["x"].default  # Assert that the default == True
-    assert parameters["y"].type_ == ConfigParameterType.NUMBER
-    assert parameters["y"].default == 3
-    assert parameters["z"].type_ == ConfigParameterType.NUMBER
-    assert parameters["z"].default == 7.5
+    assert config_template["w"].type_ == ConfigParameterType.STRING
+    assert config_template["w"].default == "deeeefault"
+    assert config_template["x"].type_ == ConfigParameterType.BOOLEAN
+    assert config_template["x"].default  # Assert that the default == True
+    assert config_template["y"].type_ == ConfigParameterType.NUMBER
+    assert config_template["y"].default == 3
+    assert config_template["z"].type_ == ConfigParameterType.NUMBER
+    assert config_template["z"].default == 7.5
 
-    assert parameters["w2"].type_ == ConfigParameterType.STRING
-    assert parameters["w2"].default is None
-    assert parameters["x2"].type_ == ConfigParameterType.BOOLEAN
-    assert parameters["x2"].default is None
-    assert parameters["y2"].type_ == ConfigParameterType.NUMBER
-    assert parameters["y2"].default is None
-    assert parameters["z2"].type_ == ConfigParameterType.NUMBER
-    assert parameters["z2"].default is None
+    assert config_template["w2"].type_ == ConfigParameterType.STRING
+    assert config_template["w2"].default is None
+    assert config_template["x2"].type_ == ConfigParameterType.BOOLEAN
+    assert config_template["x2"].default is None
+    assert config_template["y2"].type_ == ConfigParameterType.NUMBER
+    assert config_template["y2"].default is None
+    assert config_template["z2"].type_ == ConfigParameterType.NUMBER
+    assert config_template["z2"].default is None
+
+
+def test_descriptions():
+    class DescriptionConfig(Config):
+        x: int = Field(description="Test Description")
+
+    description_config = DescriptionConfig(x=3)
+    config_template = description_config.get_config_parameters()
+    assert len(config_template) == 1
+
+    # TODO: descriptions
+    assert config_template["x"].description == "Test Description"

--- a/tests/steamship_tests/app/unit/test_config_template_extraction.py
+++ b/tests/steamship_tests/app/unit/test_config_template_extraction.py
@@ -11,7 +11,7 @@ def test_config_parameters():
     assert len(config_template) == 4
     for config_param in config_template.values():
         assert config_param.default is None
-        assert config_param.type_ == ConfigParameterType.STRING
+        assert config_param.type == ConfigParameterType.STRING
 
     names = config_template.keys()
     assert "greeting" in names
@@ -29,7 +29,7 @@ def test_config_parameter_numbers():
     assert len(config_template) == 2
     for config_param in config_template.values():
         assert config_param.default is None
-        assert config_param.type_ == ConfigParameterType.NUMBER
+        assert config_param.type == ConfigParameterType.NUMBER
 
     names = config_template.keys()
     assert "x" in names
@@ -46,7 +46,7 @@ def test_config_parameter_boolean():
     assert len(config_template) == 2
     for config_param in config_template.values():
         assert config_param.default is None
-        assert config_param.type_ == ConfigParameterType.BOOLEAN
+        assert config_param.type == ConfigParameterType.BOOLEAN
 
     names = config_template.keys()
     assert "x" in names
@@ -64,13 +64,13 @@ def test_config_parameter_with_defaults():
     config_template = defaults_config.get_config_parameters()
     assert len(config_template) == 4
 
-    assert config_template["w"].type_ == ConfigParameterType.STRING
+    assert config_template["w"].type == ConfigParameterType.STRING
     assert config_template["w"].default == "deeeefault"
-    assert config_template["x"].type_ == ConfigParameterType.BOOLEAN
+    assert config_template["x"].type == ConfigParameterType.BOOLEAN
     assert config_template["x"].default  # Assert that the default == True
-    assert config_template["y"].type_ == ConfigParameterType.NUMBER
+    assert config_template["y"].type == ConfigParameterType.NUMBER
     assert config_template["y"].default == 3
-    assert config_template["z"].type_ == ConfigParameterType.NUMBER
+    assert config_template["z"].type == ConfigParameterType.NUMBER
     assert config_template["z"].default == 7.5
 
 
@@ -89,22 +89,22 @@ def test_optional_config_parameters():
     config_template = defaults_config.get_config_parameters()
     assert len(config_template) == 8
 
-    assert config_template["w"].type_ == ConfigParameterType.STRING
+    assert config_template["w"].type == ConfigParameterType.STRING
     assert config_template["w"].default == "deeeefault"
-    assert config_template["x"].type_ == ConfigParameterType.BOOLEAN
+    assert config_template["x"].type == ConfigParameterType.BOOLEAN
     assert config_template["x"].default  # Assert that the default == True
-    assert config_template["y"].type_ == ConfigParameterType.NUMBER
+    assert config_template["y"].type == ConfigParameterType.NUMBER
     assert config_template["y"].default == 3
-    assert config_template["z"].type_ == ConfigParameterType.NUMBER
+    assert config_template["z"].type == ConfigParameterType.NUMBER
     assert config_template["z"].default == 7.5
 
-    assert config_template["w2"].type_ == ConfigParameterType.STRING
+    assert config_template["w2"].type == ConfigParameterType.STRING
     assert config_template["w2"].default is None
-    assert config_template["x2"].type_ == ConfigParameterType.BOOLEAN
+    assert config_template["x2"].type == ConfigParameterType.BOOLEAN
     assert config_template["x2"].default is None
-    assert config_template["y2"].type_ == ConfigParameterType.NUMBER
+    assert config_template["y2"].type == ConfigParameterType.NUMBER
     assert config_template["y2"].default is None
-    assert config_template["z2"].type_ == ConfigParameterType.NUMBER
+    assert config_template["z2"].type == ConfigParameterType.NUMBER
     assert config_template["z2"].default is None
 
 

--- a/tests/steamship_tests/app/unit/test_config_template_extraction.py
+++ b/tests/steamship_tests/app/unit/test_config_template_extraction.py
@@ -1,0 +1,118 @@
+from typing import Optional
+
+from assets.packages.configurable_hello_world import HelloWorld
+
+from steamship.invocable.config import Config, ConfigParameterType
+
+
+def test_config_parameters():
+    package = HelloWorld(
+        config={
+            "greeting": "yo",
+            "snake_case_config": "hisss",
+            "camelCaseConfig": "spit!",
+            "defaultConfig": "default",
+        }
+    )
+    config_template = package.get_config_parameters()
+    assert len(config_template) == 4
+    for config_param in config_template:
+        assert config_param.default is None
+        assert config_param.type_ == ConfigParameterType.STRING
+
+    names = [p.name for p in config_template]
+    assert "greeting" in names
+    assert "snake_case_config" in names
+    assert "camelCaseConfig" in names
+    assert "defaultConfig" in names
+
+
+def test_config_parameter_numbers():
+    class NumberConfig(Config):
+        x: float
+        y: int
+
+    number_config = NumberConfig(x=3, y=4)
+    config_template = number_config.get_config_parameters()
+    assert len(config_template) == 2
+    for config_param in config_template:
+        assert config_param.default is None
+        assert config_param.type_ == ConfigParameterType.NUMBER
+
+    names = [p.name for p in config_template]
+    assert "x" in names
+    assert "y" in names
+
+
+def test_config_parameter_boolean():
+    class BoolConfig(Config):
+        x: bool
+        y: bool
+
+    bool_config = BoolConfig(x=True, y=False)
+    config_template = bool_config.get_config_parameters()
+    assert len(config_template) == 2
+    for config_param in config_template:
+        assert config_param.default is None
+        assert config_param.type_ == ConfigParameterType.BOOLEAN
+
+    names = [p.name for p in config_template]
+    assert "x" in names
+    assert "y" in names
+
+
+def test_config_parameter_with_defaults():
+    class DefaultsConfig(Config):
+        w: str = "deeeefault"
+        x: bool = True
+        y: int = 3
+        z: float = 7.5
+
+    defaults_config = DefaultsConfig()
+    config_template = defaults_config.get_config_parameters()
+    assert len(config_template) == 4
+
+    parameters = {p.name: p for p in config_template}
+    assert parameters["w"].type_ == ConfigParameterType.STRING
+    assert parameters["w"].default == "deeeefault"
+    assert parameters["x"].type_ == ConfigParameterType.BOOLEAN
+    assert parameters["x"].default  # Assert that the default == True
+    assert parameters["y"].type_ == ConfigParameterType.NUMBER
+    assert parameters["y"].default == 3
+    assert parameters["z"].type_ == ConfigParameterType.NUMBER
+    assert parameters["z"].default == 7.5
+
+
+def test_optional_config_parameters():
+    class DefaultsConfig(Config):
+        w: Optional[str] = "deeeefault"
+        w2: Optional[str]
+        x: Optional[bool] = True
+        x2: Optional[bool]
+        y: Optional[int] = 3
+        y2: Optional[int]
+        z: Optional[float] = 7.5
+        z2: Optional[float]
+
+    defaults_config = DefaultsConfig()
+    config_template = defaults_config.get_config_parameters()
+    assert len(config_template) == 8
+
+    parameters = {p.name: p for p in config_template}
+    assert parameters["w"].type_ == ConfigParameterType.STRING
+    assert parameters["w"].default == "deeeefault"
+    assert parameters["x"].type_ == ConfigParameterType.BOOLEAN
+    assert parameters["x"].default  # Assert that the default == True
+    assert parameters["y"].type_ == ConfigParameterType.NUMBER
+    assert parameters["y"].default == 3
+    assert parameters["z"].type_ == ConfigParameterType.NUMBER
+    assert parameters["z"].default == 7.5
+
+    assert parameters["w2"].type_ == ConfigParameterType.STRING
+    assert parameters["w2"].default is None
+    assert parameters["x2"].type_ == ConfigParameterType.BOOLEAN
+    assert parameters["x2"].default is None
+    assert parameters["y2"].type_ == ConfigParameterType.NUMBER
+    assert parameters["y2"].default is None
+    assert parameters["z2"].type_ == ConfigParameterType.NUMBER
+    assert parameters["z2"].default is None

--- a/tests/steamship_tests/plugin/unit/test_service.py
+++ b/tests/steamship_tests/plugin/unit/test_service.py
@@ -38,7 +38,8 @@ class ValidTrainableStringToStringModel(TrainableModel[EmptyConfig]):
 
 
 class ValidTrainableStringToStringPlugin(TrainableTagger):
-    def config_cls(self) -> Type[Config]:
+    @classmethod
+    def config_cls(cls) -> Type[Config]:
         return EmptyConfig
 
     def model_cls(self) -> Type[TrainableModel]:
@@ -80,7 +81,8 @@ def test_plugin_service_is_abstract():
 
 def test_plugin_service_must_implement_run_and_subclass_request_from_dict():
     class BadPlugin(PluginService):
-        def config_cls(self) -> Type[Config]:
+        @classmethod
+        def config_cls(cls) -> Type[Config]:
             return Config
 
     with pytest.raises(TypeError):


### PR DESCRIPTION
This PR builds in a minimal first CLI directly into the Python SDK package.

It currently supports only two commands:
`ship login`
`ship deploy`
and the latter only supports packages.

New features vs. Typescript CLI:
- If no auth is available, will try to login on instantiation of `Steamship()`.  If no browser available, throws exception.
- If `steamship.json` doesn't exist during deploy, walk the user through creation
- deploy command will update config template based on the Config python object in the package (outputs the new template if changed)
- If a package handle already exists and is owned by someone else, the deploy will prompt the user for a new one 

Plugin support will be straightforward to add (mostly more manifest fields), but left it out so we could get rolling with this.