### PR TITLE
attempt to fix import issue

### DIFF
--- a/src/steamship/cli/deploy.py
+++ b/src/steamship/cli/deploy.py
@@ -30,7 +30,7 @@ DEFAULT_BUILD_IGNORE = [
 ]
 
 
-def update_config_template(manifest: Manifest):  # noqa: C901
+def update_config_template(manifest: Manifest):
 
     path = Path("src/api.py")
     if not path.exists():


### PR DESCRIPTION
Disclaimer: I have no idea what I'm doing here. The code could use a bunch of refactoring, if it is even the "right" solution. This is merely an attempt at sketching out a possible approach. 

Problem statement:  Running `ship deploy` with more than just `api.py` in your package breaks because of modules not being found.

This PR attempts to address that by recursing through the directories with python files and trying to load (and exec?) them.

I have only validated this with parallel files and **one** package at a subdirectory. I have not validated this with more complex deployments, etc. As soon as I got _something_ working, I pushed this PR to allow for others to play and optimize while I sleep.