### PR TITLE
Initial version of test-instance command

### DIFF
--- a/src/steamship/data/manifest.py
+++ b/src/steamship/data/manifest.py
@@ -31,6 +31,14 @@ class ConfigParameter(BaseModel):
     # Use strict so that Pydantic doesn't coerce values into the first one that fits
     default: Optional[Union[StrictStr, StrictBool, StrictFloat, StrictInt]] = None
 
+    def parameter_value_from_string(self, string: str):
+        if type == ConfigParameterType.BOOLEAN:
+            return string.lower() == "true"
+        elif type == ConfigParameterType.NUMBER:
+            return float(string)
+        else:
+            return string
+
 
 class DeployableType(str, Enum):
     PLUGIN = "plugin"


### PR DESCRIPTION
Per discussion here (thanks @gregwhelan):

https://discordapp.com/channels/927675537390968882/1073669075718389851

This initial version allows creation of a test instance of a package from the command line. Takes config params if your package requires them.

I made it as `test-instance` and not a more generic `create-instance` so that I could make some assumptions about creating / reusing a particular workspace.

Right now I have it outputting a little json dict, so that it's clear that you got an instance of the version you wanted, and you can see the config (if your package has config)
Could add a --url-only option or something to have it only spit out the invocation url if piping through jq feels like too much of a pain for scripting