### PR TITLE
Add configuration  hash to auto-named handles

### DIFF
--- a/src/steamship/client/steamship.py
+++ b/src/steamship/client/steamship.py
@@ -19,6 +19,7 @@ from steamship.data.plugin.index_plugin_instance import EmbeddingIndexPluginInst
 from steamship.data.plugin.plugin_instance import PluginInstance
 from steamship.data.plugin.prompt_generation_plugin_instance import PromptGenerationPluginInstance
 from steamship.data.workspace import Workspace
+from steamship.utils.metadata import hash_dict
 
 _logger = logging.getLogger(__name__)
 
@@ -177,8 +178,13 @@ class Steamship(Client):
         The instance is named `instance_handle` and located in the workspace this client is anchored to.
         If no `instance_handle` is provided, the default is `package_handle`.
         """
+
         if instance_handle is None:
-            instance_handle = package_handle
+            if config is None:
+                instance_handle = package_handle
+            else:
+                instance_handle = f"{package_handle}-{hash_dict(config)}"
+
         return PackageInstance.create(
             self,
             package_handle=package_handle,
@@ -276,7 +282,10 @@ class Steamship(Client):
         """
 
         if instance_handle is None:
-            instance_handle = plugin_handle
+            if config is None:
+                instance_handle = plugin_handle
+            else:
+                instance_handle = f"{plugin_handle}-{hash_dict(config)}"
 
         if plugin_handle in Steamship._PLUGIN_INSTANCE_SUBCLASS_OVERRIDES:
             return Steamship._PLUGIN_INSTANCE_SUBCLASS_OVERRIDES[plugin_handle].create(

--- a/src/steamship/utils/metadata.py
+++ b/src/steamship/utils/metadata.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from typing import Dict, List, Optional, Union
 
@@ -14,3 +15,12 @@ def metadata_to_str(m: Metadata) -> Optional[str]:
     if m is None:
         return None
     return json.dumps(m)
+
+
+def hash_dict(d: Dict) -> str:
+    """Returns the MD5 hash of a dictionary."""
+    dhash = hashlib.md5()  # noqa: S303
+    # Sort arguments so so that the string representation is always the same.
+    encoded = json.dumps(d, sort_keys=True).encode()
+    dhash.update(encoded)
+    return dhash.hexdigest()


### PR DESCRIPTION
Steamship configs are immutable; the following two lines will error because they attempt to load the same package instance (`instanceHandle`) with differing configurations:

```
Steamship.use('packageHandle', 'instanceHandle', config={"name"="Larry"}) # Sometimes works; if not done before with different config
Steamship.use('packageHandle', 'instanceHandle', config={"name"="Curly"}) # Always fails, since we know config differs
```

When the instanceHandle is not provided, a default is provided, equal to the packageHandle/pluginHandle:

```
Steamship.use('packageHandle', config={"name"="Larry"}) # Sometimes works; if not done before with different config
Steamship.use('packageHandle', config={"name"="Curly"}) # Always fails, since we know config differs
```

This is good in that it hard-errors early to enforce the immutable config, but potentially confusing to newcomers who expect more typical construction semantics.

Further, it presents a particular challenge if one **intends to have configuration be dynamic**. An example of this would be an argument to a package method which, itself, parameterizes a plugin which must be used in that method's implementation.

In that scenario, our present handling makes:

* "Anonyous" packages/plugins are impossible (as two different configs would be provided to the default instance handle), and
* "non-anonyous" packages/plugins require the name to encode the config object which parameterizes them

That effectively renders dynamic configuration impossible unless the developer knows to hash the entire config object into the handle, which is very unlikely to be apparent without explanation.

# This PR

This PR solves the problem by doing what the developer would have to do anyway: hashing the config object into the auto-generated handle for them.

When an anonymous package/plugin is used with a non-None config block, the default name is changed from:


```
{packageName}
```

to

```
{packageName}-{md5(config)}
```

This renders the following block of code always runnable:

```
Steamship.use('package', config={"name"="Larry"})  # Always works
Steamship.use('package', config={"name"="Curly"})  # Always works
```

## Not Changed

This PR does not change the semantics of the NAMED instance invocation. Those semantics remain the same: once actively named by the user, the config can not change. 


## Shoutout

Thanks for the catch @ytang07!
