### PR TITLE
feat: add logs retrieval to ship cli

### DIFF
--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -4,7 +4,7 @@ import logging
 import typing
 from abc import ABC
 from inspect import isclass
-from typing import Any, List, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import inflection
 from pydantic import BaseModel, PrivateAttr
@@ -564,3 +564,37 @@ class Client(CamelModel, ABC):
             as_background_task=as_background_task,
             wait_on_tasks=wait_on_tasks,
         )
+
+    def logs(
+        self,
+        offset: int = 0,
+        number: int = 50,
+        invocable_handle: Optional[str] = None,
+        instance_handle: Optional[str] = None,
+        invocable_version_handle: Optional[str] = None,
+        path: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Return generated logs for a client.
+
+        The logs will be workspace-scoped. You will only receive logs
+        for packages and plugins that you own.
+
+        :param offset: The index of the first log entry to return. This can be used with `number` to page through logs.
+        :param number: The number of log entries to return. This can be used with `offset` to page through logs.
+        :param invocable_handle: Enables optional filtering based on the handle of package or plugin. Example: `my-package`
+        :param instance_handle: Enables optional filtering based on the handle of package instance or plugin instance. Example: `my-instance`
+        :param invocable_version_handle: Enables optional filtering based on the version handle of package or plugin. Example: `0.0.2`
+        :param path: Enables optional filtering based on request path. Example: `/generate`.
+        :return: Returns a dictionary containing the offset and number of log entries as well as a list of `entries` that match the specificed filters.
+        """
+        args = {"from": offset, "size": number}
+        if invocable_handle:
+            args["invocableHandle"] = invocable_handle
+        if instance_handle:
+            args["invocableInstanceHandle"] = instance_handle
+        if invocable_version_handle:
+            args["invocableVersionHandle"] = invocable_version_handle
+        if path:
+            args["invocablePath"] = path
+
+        return self.post("logs/list", args)

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -161,6 +161,7 @@ def deploy():
 )
 @click.option(
     "--path",
+    "request_path",
     type=str,
     help="Path invoked by a client operation. Used to filter logs returned to a specific invocation path.",
 )
@@ -171,7 +172,7 @@ def logs(
     package: Optional[str] = None,
     instance: Optional[str] = None,
     version: Optional[str] = None,
-    path: Optional[str] = None,
+    request_path: Optional[str] = None,
 ):
     initialize(suppress_message=True)
     client = None
@@ -180,17 +181,7 @@ def logs(
     except SteamshipError as e:
         raise click.UsageError(message=e.message)
 
-    args = {"from": offset, "size": number}
-    if package:
-        args["invocableHandle"] = package
-    if instance:
-        args["invocableInstanceHandle"] = instance
-    if version:
-        args["invocableVersionHandle"] = version
-    if path:
-        args["invocablePath"] = path
-    resp = client.post("logs/list", args)
-    click.echo(json.dumps(resp))
+    click.echo(json.dumps(client.logs(offset, number, package, instance, version, request_path)))
 
 
 cli.add_command(login)

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -1,7 +1,9 @@
+import json
 import logging
 import sys
 import time
 from os import path
+from typing import Optional
 
 import click
 
@@ -26,9 +28,10 @@ def cli():
     pass
 
 
-def initialize():
+def initialize(suppress_message: bool = False):
     logging.root.setLevel(logging.FATAL)
-    click.echo(f"Steamship PYTHON cli version {steamship.__version__}")
+    if not suppress_message:
+        click.echo(f"Steamship PYTHON cli version {steamship.__version__}")
 
 
 @click.command()
@@ -114,6 +117,80 @@ def deploy():
     # - Version handle already deployed. [handled; asks user for new]
     # - Bad parameter configuration. [mitigated by deriving template from Config object]
     # - Package content fails health check (ex. bad import) [Error caught while checking config object]
+
+
+@click.command()
+@click.option(
+    "--workspace",
+    "-w",
+    required=True,
+    type=str,
+    help="Workspace handle used for scoping logs request. All requests MUST be scoped by workspace.",
+)
+@click.option(
+    "--offset",
+    "-o",
+    default=0,
+    type=int,
+    help="Starting index from sorted logs to return a chunk. Used for paging. Defaults to 0.",
+)
+@click.option(
+    "--number",
+    "-n",
+    default=50,
+    type=int,
+    help="Number of logs to return in a single batch. Defaults to 50.",
+)
+@click.option(
+    "--package",
+    "-p",
+    type=str,
+    help="Package handle. Used to filter logs returend to a specific package (across all instances).",
+)
+@click.option(
+    "--instance",
+    "-i",
+    type=str,
+    help="Instance handle. Used to filter logs returned to a specific instance of a package.",
+)
+@click.option(
+    "--version",
+    "-v",
+    type=str,
+    help="Version handle. Used to filter logs returned to a specific version of a package.",
+)
+@click.option(
+    "--path",
+    type=str,
+    help="Path invoked by a client operation. Used to filter logs returned to a specific invocation path.",
+)
+def logs(
+    workspace: str,
+    offset: int,
+    number: int,
+    package: Optional[str] = None,
+    instance: Optional[str] = None,
+    version: Optional[str] = None,
+    path: Optional[str] = None,
+):
+    initialize(suppress_message=True)
+    client = None
+    try:
+        client = Steamship(workspace=workspace)
+    except SteamshipError as e:
+        raise click.UsageError(message=e.message)
+
+    args = {"from": offset, "size": number}
+    if package:
+        args["invocableHandle"] = package
+    if instance:
+        args["invocableInstanceHandle"] = instance
+    if version:
+        args["invocableVersionHandle"] = version
+    if path:
+        args["invocablePath"] = path
+    resp = client.post("logs/list", args)
+    click.echo(json.dumps(resp))
 
 
 cli.add_command(login)

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -188,6 +188,8 @@ cli.add_command(login)
 cli.add_command(deploy)
 cli.add_command(deploy, name="it")
 cli.add_command(ships)
+cli.add_command(logs)
+
 
 if __name__ == "__main__":
     deploy([])


### PR DESCRIPTION
This adds a command to the `ship` CLI to support logs retrieval.

Users can use it in conjunction with `jq` to retrieve and parse logs in their workspaces (filtering by package/instance/version/path).

Example usage:

```bash
ship logs --workspace my-prod-workspace  --path '/generate'  | jq '.entries[].message'
```

This should allow developers to quickly access pertinent logs for their packages without having to visit the web UI.