### PR TITLE
Explicitly wait on snapshot creation in index_plugin_instance

### DIFF
--- a/src/steamship/data/embeddings.py
+++ b/src/steamship/data/embeddings.py
@@ -251,7 +251,7 @@ class EmbeddingIndex(CamelModel):
             expect=IndexEmbedResponse,
         )
 
-    def create_snapshot(self) -> IndexSnapshotResponse:
+    def create_snapshot(self) -> Task[IndexSnapshotResponse]:
         req = IndexSnapshotRequest(index_id=self.id)
         return self.client.post(
             "embedding-index/snapshot/create",

--- a/src/steamship/data/plugin/index_plugin_instance.py
+++ b/src/steamship/data/plugin/index_plugin_instance.py
@@ -143,7 +143,8 @@ class EmbeddingIndexPluginInstance(PluginInstance):
 
         # We always snapshot in this new style; to not do so is to expose details we'd rather not have
         # users exercise control over.
-        self.index.create_snapshot()
+        response = self.index.create_snapshot()
+        response.wait()
 
     def search(self, query: str, k: Optional[int] = None) -> Task[SearchResults]:
         """Search the embedding index.


### PR DESCRIPTION
This isn't really a fix, but possibly a reliability band-aid for vector search