### PR TITLE
default to protecting api key in serializations

### DIFF
--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -188,12 +188,28 @@ class Client(CamelModel, ABC):
         # implementations), Pydantic will try to include them by default. So we have to suppress that otherwise
         # downstream serialization into JSON will fail.
         if "exclude" not in kwargs:
-            kwargs["exclude"] = {"use", "use_plugin", "_instance_use", "_instance_use_plugin"}
+            kwargs["exclude"] = {
+                "use": True,
+                "use_plugin": True,
+                "_instance_use": True,
+                "_instance_use_plugin": True,
+                "config": {"api_key"},
+            }
         elif isinstance(kwargs["exclude"], set):
             kwargs["exclude"].add("use")
             kwargs["exclude"].add("use_plugin")
             kwargs["exclude"].add("_instance_use")
             kwargs["exclude"].add("_instance_use_plugin")
+            kwargs["exclude"].add(
+                "config"
+            )  # the set version cannot exclude subcomponents; we must remove all config
+        elif isinstance(kwargs["exclude"], dict):
+            kwargs["exclude"]["use"] = True
+            kwargs["exclude"]["use_plugin"] = True
+            kwargs["exclude"]["_instance_use"] = True
+            kwargs["exclude"]["_instance_use_plugin"] = True
+            kwargs["exclude"]["config"] = {"api_key"}
+
         return super().dict(**kwargs)
 
     def _url(

--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -237,7 +237,7 @@ class Client(CamelModel, ABC):
         as_background_task: bool = False,
         wait_on_tasks: List[Union[str, Task]] = None,
     ):
-        headers = {"Authorization": f"Bearer {self.config.api_key}"}
+        headers = {"Authorization": f"Bearer {self.config.api_key.get_secret_value()}"}
 
         if self.config.workspace_id:
             headers["X-Workspace-Id"] = self.config.workspace_id

--- a/src/steamship/base/configuration.py
+++ b/src/steamship/base/configuration.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 import inflection
-from pydantic import HttpUrl
+from pydantic import HttpUrl, SecretStr
 
 from steamship.base.model import CamelModel
 from steamship.cli.login import login
@@ -37,7 +37,7 @@ EXCLUDE_FROM_DICT = {
 
 
 class Configuration(CamelModel):
-    api_key: str
+    api_key: SecretStr
     api_base: HttpUrl = DEFAULT_API_BASE
     app_base: HttpUrl = DEFAULT_APP_BASE
     web_base: HttpUrl = DEFAULT_WEB_BASE

--- a/tests/assets/packages/demo_package.py
+++ b/tests/assets/packages/demo_package.py
@@ -117,7 +117,7 @@ class TestPackage(PackageService):
                 "workspaceId": self.client.config.workspace_id,
                 "appBase": self.client.config.app_base,
                 "apiBase": self.client.config.api_base,
-                "apiKey": self.client.config.api_key,
+                "apiKey": self.client.config.api_key.get_secret_value(),
             }
         )
 

--- a/tests/steamship_tests/app/integration/test_package_instance.py
+++ b/tests/steamship_tests/app/integration/test_package_instance.py
@@ -42,7 +42,7 @@ def test_instance_invoke():
         def get_raw(path: str):
             return requests.get(
                 instance.full_url_for(path),
-                headers={"authorization": f"Bearer {client.config.api_key}"},
+                headers={"authorization": f"Bearer {client.config.api_key.get_secret_value()}"},
             )
 
         res = instance.invoke("greet", verb=Verb.GET)
@@ -54,13 +54,17 @@ def test_instance_invoke():
         res = instance.invoke("greet", verb=Verb.GET, name="Ted")
         assert res == "Hello, Ted!"
         url = instance.full_url_for("greet?name=Ted")
-        resp = requests.get(url, headers={"authorization": f"Bearer {client.config.api_key}"})
+        resp = requests.get(
+            url, headers={"authorization": f"Bearer {client.config.api_key.get_secret_value()}"}
+        )
         assert resp.text == "Hello, Ted!"
 
         res = instance.invoke("greet", verb=Verb.POST)
         assert res == "Hello, Person!"
         url = instance.full_url_for("greet")
-        resp = requests.post(url, headers={"authorization": f"Bearer {client.config.api_key}"})
+        resp = requests.post(
+            url, headers={"authorization": f"Bearer {client.config.api_key.get_secret_value()}"}
+        )
         assert resp.text == "Hello, Person!"
 
         res = instance.invoke("greet", verb=Verb.POST, name="Ted")
@@ -69,7 +73,7 @@ def test_instance_invoke():
         resp = requests.post(
             url,
             json={"name": "Ted"},
-            headers={"authorization": f"Bearer {client.config.api_key}"},
+            headers={"authorization": f"Bearer {client.config.api_key.get_secret_value()}"},
         )
         assert resp.text == "Hello, Ted!"
 
@@ -121,7 +125,7 @@ def test_instance_invoke():
         assert my_api_base == remote_api_base
 
         # API key should NOT be the same as the original, because the invocable should be given a workspace-scoped key
-        assert configuration_within_lambda["apiKey"] != client.config.api_key
+        assert configuration_within_lambda["apiKey"] != client.config.api_key.get_secret_value()
 
         # WorkspaceId is an exception. Rather than being the WorkspaceId of the client, it should be the WorkspaceId
         # of the App Instance.

--- a/tests/steamship_tests/base/test_serialization.py
+++ b/tests/steamship_tests/base/test_serialization.py
@@ -28,6 +28,16 @@ def test_serialize_client_to_json_works(client: Steamship):
     j = json.dumps(client.dict())  # this will fail if `use` or `use_plugin` are output by dict()
     assert j is not None
 
+    j = json.dumps(
+        client.dict(exclude={"foo"})
+    )  # this will fail if `use` or `use_plugin` are output by dict()
+    assert j is not None
+
+    j = json.dumps(
+        client.dict(exclude={"foo": True})
+    )  # this will fail if `use` or `use_plugin` are output by dict()
+    assert j is not None
+
 
 @pytest.mark.usefixtures("client")
 def test_serialize_many_models(client: Steamship):


### PR DESCRIPTION
Better safe than sorry. Preventing log leakage with API Keys, etc., seems like the right default stance.