### PR TITLE
Add optional HTTP timeouts to package invocations

### DIFF
--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -398,6 +398,7 @@ class Client(CamelModel, ABC):
         package_instance_id: str = None,
         as_background_task: bool = False,
         wait_on_tasks: List[Union[str, Task]] = None,
+        timeout_s: Optional[float] = None
     ) -> Union[
         Any, Task
     ]:  # TODO (enias): I would like to list all possible return types using interfaces instead of Any
@@ -439,11 +440,11 @@ class Client(CamelModel, ABC):
         if verb == Verb.POST:
             if file is not None:
                 files = self._prepare_multipart_data(data, file)
-                resp = self._session.post(url, files=files, headers=headers)
+                resp = self._session.post(url, files=files, headers=headers, timeout=timeout_s)
             else:
-                resp = self._session.post(url, json=data, headers=headers)
+                resp = self._session.post(url, json=data, headers=headers, timeout=timeout_s)
         elif verb == Verb.GET:
-            resp = self._session.get(url, params=data, headers=headers)
+            resp = self._session.get(url, params=data, headers=headers, timeout=timeout_s)
         else:
             raise Exception(f"Unsupported verb: {verb}")
 
@@ -529,6 +530,7 @@ class Client(CamelModel, ABC):
         package_instance_id: str = None,
         as_background_task: bool = False,
         wait_on_tasks: List[Union[str, Task]] = None,
+        timeout_s: Optional[float] = None,
     ) -> Union[
         Any, Task
     ]:  # TODO (enias): I would like to list all possible return types using interfaces instead of Any
@@ -546,6 +548,7 @@ class Client(CamelModel, ABC):
             package_instance_id=package_instance_id,
             as_background_task=as_background_task,
             wait_on_tasks=wait_on_tasks,
+            timeout_s=timeout_s,
         )
 
     def get(
@@ -562,6 +565,8 @@ class Client(CamelModel, ABC):
         package_instance_id: str = None,
         as_background_task: bool = False,
         wait_on_tasks: List[Union[str, Task]] = None,
+        timeout_s: Optional[float] = None,
+
     ) -> Union[
         Any, Task
     ]:  # TODO (enias): I would like to list all possible return types using interfaces instead of Any
@@ -579,6 +584,7 @@ class Client(CamelModel, ABC):
             package_instance_id=package_instance_id,
             as_background_task=as_background_task,
             wait_on_tasks=wait_on_tasks,
+            timeout_s=timeout_s,
         )
 
     def logs(

--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -398,7 +398,7 @@ class Client(CamelModel, ABC):
         package_instance_id: str = None,
         as_background_task: bool = False,
         wait_on_tasks: List[Union[str, Task]] = None,
-        timeout_s: Optional[float] = None
+        timeout_s: Optional[float] = None,
     ) -> Union[
         Any, Task
     ]:  # TODO (enias): I would like to list all possible return types using interfaces instead of Any
@@ -566,7 +566,6 @@ class Client(CamelModel, ABC):
         as_background_task: bool = False,
         wait_on_tasks: List[Union[str, Task]] = None,
         timeout_s: Optional[float] = None,
-
     ) -> Union[
         Any, Task
     ]:  # TODO (enias): I would like to list all possible return types using interfaces instead of Any

--- a/src/steamship/data/package/package_instance.py
+++ b/src/steamship/data/package/package_instance.py
@@ -88,7 +88,7 @@ class PackageInstance(CamelModel):
             "package/instance/get", IdentifierRequest(handle=handle), expect=PackageInstance
         )
 
-    def invoke(self, path: str, verb: Verb = Verb.POST, **kwargs):
+    def invoke(self, path: str, verb: Verb = Verb.POST, timeout_s: Optional[float] = None, **kwargs):
         self.load_missing_workspace_handle()
         if path[0] == "/":
             path = path[1:]
@@ -102,6 +102,7 @@ class PackageInstance(CamelModel):
             package_id=self.package_id,
             package_instance_id=self.id,
             as_background_task=False,
+            timeout_s=timeout_s,
         )
 
     def full_url_for(self, path: str):

--- a/src/steamship/data/package/package_instance.py
+++ b/src/steamship/data/package/package_instance.py
@@ -88,7 +88,9 @@ class PackageInstance(CamelModel):
             "package/instance/get", IdentifierRequest(handle=handle), expect=PackageInstance
         )
 
-    def invoke(self, path: str, verb: Verb = Verb.POST, timeout_s: Optional[float] = None, **kwargs):
+    def invoke(
+        self, path: str, verb: Verb = Verb.POST, timeout_s: Optional[float] = None, **kwargs
+    ):
         self.load_missing_workspace_handle()
         if path[0] == "/":
             path = path[1:]

--- a/tests/steamship_tests/app/integration/test_package_instance.py
+++ b/tests/steamship_tests/app/integration/test_package_instance.py
@@ -5,7 +5,6 @@ import re
 import pytest
 import requests
 from requests import ConnectTimeout
-
 from steamship_tests import PACKAGES_PATH, TEST_ASSETS_PATH
 from steamship_tests.utils.deployables import deploy_package
 from steamship_tests.utils.fixtures import get_steamship_client
@@ -229,7 +228,6 @@ def test_plugin_instance_handle_refs():
     assert workspace.handle != "default"
 
     with deploy_package(steamship, demo_package_path) as (package, version, instance):
-
         assert instance.package_handle == package.handle
         assert instance.package_version_handle == version.handle
 
@@ -241,6 +239,7 @@ def test_plugin_instance_handle_refs():
         use_instance = steamship.use(package_handle=package.handle, version=version.handle)
         assert use_instance.package_handle == package.handle
         assert use_instance.package_version_handle == version.handle
+
 
 def test_package_invoke_timeout():
     client = get_steamship_client()

--- a/tests/steamship_tests/app/integration/test_package_instance.py
+++ b/tests/steamship_tests/app/integration/test_package_instance.py
@@ -4,6 +4,8 @@ import re
 
 import pytest
 import requests
+from requests import ConnectTimeout
+
 from steamship_tests import PACKAGES_PATH, TEST_ASSETS_PATH
 from steamship_tests.utils.deployables import deploy_package
 from steamship_tests.utils.fixtures import get_steamship_client
@@ -239,3 +241,14 @@ def test_plugin_instance_handle_refs():
         use_instance = steamship.use(package_handle=package.handle, version=version.handle)
         assert use_instance.package_handle == package.handle
         assert use_instance.package_version_handle == version.handle
+
+def test_package_invoke_timeout():
+    client = get_steamship_client()
+    demo_package_path = PACKAGES_PATH / "demo_package.py"
+
+    with client.temporary_workspace() as client:
+        with deploy_package(client, demo_package_path) as (_, _, instance):
+            with pytest.raises(ConnectTimeout):
+                _ = instance.invoke("greet", verb=Verb.GET, timeout_s=0.001)
+            with pytest.raises(ConnectTimeout):
+                _ = instance.invoke("greet", verb=Verb.POST, timeout_s=0.001)


### PR DESCRIPTION
Helpful for applications that might need to bail out quickly if the service doesn't respond (ex: Clockbot) :)