### PR TITLE
Two Minor test improvements

### DIFF
--- a/tests/steamship_tests/base/test_configuration.py
+++ b/tests/steamship_tests/base/test_configuration.py
@@ -54,7 +54,9 @@ def test_empty_base_uris() -> None:
 def test_empty_api_key() -> None:
 
     # Only run this test on non-local (i.e., CI/CD) otherwise will attempt browser login
-    if webbrowser.get() is None:
+    try:
+        _ = webbrowser.get()
+    except webbrowser.Error:
         with pytest.raises(SteamshipError):
             # Note: We're referencing a non existing profile to make sure the api key is not loaded from the default profile in steamship.json
             Configuration(api_key=None, profile="non-existing-profile")

--- a/tests/steamship_tests/base/test_configuration.py
+++ b/tests/steamship_tests/base/test_configuration.py
@@ -1,4 +1,5 @@
 import os
+import webbrowser
 from unittest import mock
 
 import pytest
@@ -51,6 +52,9 @@ def test_empty_base_uris() -> None:
 
 @mock.patch.dict(os.environ, {"STEAMSHIP_API_KEY": ""})
 def test_empty_api_key() -> None:
-    with pytest.raises(SteamshipError):
-        # Note: We're referencing a non existing profile to make sure the api key is not loaded from the default profile in steamship.json
-        Configuration(api_key=None, profile="non-existing-profile")
+
+    # Only run this test on non-local (i.e., CI/CD) otherwise will attempt browser login
+    if webbrowser.get() is None:
+        with pytest.raises(SteamshipError):
+            # Note: We're referencing a non existing profile to make sure the api key is not loaded from the default profile in steamship.json
+            Configuration(api_key=None, profile="non-existing-profile")

--- a/tests/steamship_tests/utils/deployables.py
+++ b/tests/steamship_tests/utils/deployables.py
@@ -4,7 +4,6 @@ import logging
 import os
 import subprocess  # noqa: S404
 import tempfile
-import time
 import zipfile
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -172,5 +171,4 @@ def _delete_deployable(instance, version, deployable):
 
 
 def _wait_for_version(version: [PackageVersion, PluginVersion]):
-    time.sleep(15)
     assert version is not None


### PR DESCRIPTION
- It's no longer necessary to wait on deploying things, as the deploy chain includes health check and thus waits engine-side
- Skip the empty API key test when running in an env with a browser (locally) so that it doesn't try to log you in 