### PR TITLE
Block large embeddings before insertion (with available override)

### DIFF
--- a/src/steamship/data/plugin/index_plugin_instance.py
+++ b/src/steamship/data/plugin/index_plugin_instance.py
@@ -98,7 +98,7 @@ class EmbeddingIndexPluginInstance(PluginInstance):
         """
         return self.index.delete()
 
-    def insert(self, tags: Union[Tag, List[Tag]]):
+    def insert(self, tags: Union[Tag, List[Tag]], allow_long_records: bool = False):
         """Insert tags into the embedding index."""
 
         # Make a list if a single tag was provided
@@ -139,7 +139,7 @@ class EmbeddingIndexPluginInstance(PluginInstance):
 
         # We always reindex in this new style; to not do so is to expose details (when embedding occurrs) we'd rather
         # not have users exercise control over.
-        self.index.insert_many(embedded_items, reindex=True)
+        self.index.insert_many(embedded_items, reindex=True, allow_long_records=allow_long_records)
 
         # We always snapshot in this new style; to not do so is to expose details we'd rather not have
         # users exercise control over.

--- a/tests/steamship_tests/client/operations/test_embedding_index.py
+++ b/tests/steamship_tests/client/operations/test_embedding_index.py
@@ -3,6 +3,7 @@ from steamship_tests.utils.fixtures import get_steamship_client
 from steamship_tests.utils.random import random_index, random_name
 
 from steamship import SteamshipError, Tag
+from steamship.data.embeddings import EmbeddedItem
 
 _TEST_EMBEDDER = "test-embedder"
 
@@ -188,3 +189,34 @@ def test_empty_queries():
 
         with pytest.raises(SteamshipError):
             index.search("  ")
+
+
+def test_oversize_insert_fails():
+    steamship = get_steamship_client()
+    long_long_string = "x" * 9999
+    with random_index(steamship, _TEST_EMBEDDER) as index_plugin_instance:
+
+        with pytest.raises(SteamshipError):
+            index_plugin_instance.insert(tags=Tag(text=long_long_string))
+
+        index = index_plugin_instance.index
+        with pytest.raises(SteamshipError):
+            index.insert(value=long_long_string)
+        with pytest.raises(SteamshipError):
+            index.insert_many(items=[long_long_string])
+        with pytest.raises(SteamshipError):
+            index.insert_many(items=[EmbeddedItem(value=long_long_string)])
+
+
+def test_oversize_insert_override():
+    steamship = get_steamship_client()
+    long_long_string = "x" * 9999
+    with random_index(steamship, _TEST_EMBEDDER) as index_plugin_instance:
+
+        index_plugin_instance.insert(tags=Tag(text=long_long_string), allow_long_records=True)
+
+        index = index_plugin_instance.index
+        index.insert(value=long_long_string, allow_long_records=True)
+        index.insert_many(items=[long_long_string], allow_long_records=True)
+        index.insert_many(items=[EmbeddedItem(value=long_long_string)], allow_long_records=True)
+        assert len(index.list_items().items) == 4


### PR DESCRIPTION
This is an additional mitigation towards issues with failed embedding index insertions.  If you attempt to embed a string longer than 5000 characters, it will be rejected within the SDK unless you pass the override flag.