### PR TITLE
Fail on bad results from server

### DIFF
--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -455,6 +455,11 @@ class Client(CamelModel, ABC):
 
         response_data = self._response_data(resp, raw_response=raw_response)
 
+        if not resp.ok:
+            raise SteamshipError(
+                f"API call did not complete successfully.  Server returned: {response_data}"
+            )
+
         logging.debug(f"Response JSON {response_data}")
 
         task = None

--- a/tests/steamship_tests/client/operations/test_embedding_index.py
+++ b/tests/steamship_tests/client/operations/test_embedding_index.py
@@ -220,3 +220,18 @@ def test_oversize_insert_override():
         index.insert_many(items=[long_long_string], allow_long_records=True)
         index.insert_many(items=[EmbeddedItem(value=long_long_string)], allow_long_records=True)
         assert len(index.list_items().items) == 4
+
+
+def test_embedding_failures():
+    steamship = get_steamship_client()
+
+    with random_index(steamship, _TEST_EMBEDDER) as index_plugin_instance:
+        index_plugin_instance.insert(Tag(text="OK"))
+        string_chunks = [
+            "Happy happy",
+            'PYTHONPATH="$PWD/.." asv [remaining arguments].',
+            "joy joy",
+        ]
+        tags = [Tag(text=t) for t in string_chunks]
+        with pytest.raises(SteamshipError):
+            index_plugin_instance.insert(tags)


### PR DESCRIPTION
This PR makes it so that the index plugin instance won't gloss over the failure to insert a record.

The fix is broader, though - any non OK statuses in client.call will now throw an error instead of returning String.