### PR TITLE
fix: ensure expectation is met in lookups/creates

### DIFF
--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -516,6 +516,15 @@ class Client(CamelModel, ABC):
 
         elif task is not None:
             return task
+        elif data is not None and expect is not None:
+            # if we have data AND we expect it to be of a certain type,
+            # we should probably make sure that expectation is met.
+            if not isinstance(data, expect):
+                raise SteamshipError(
+                    message=f"Inconsistent response from server (data does not match expected type: {expect}.)",
+                    suggestion="Please contact support via hello@steamship.com and report what caused this error.",
+                )
+            return data
         elif data is not None:
             return data
         else:

--- a/tests/steamship_tests/data/test_file.py
+++ b/tests/steamship_tests/data/test_file.py
@@ -1,6 +1,8 @@
+import io
 import json
 
 import pytest
+import requests
 from steamship_tests import PLUGINS_PATH
 from steamship_tests.utils.deployables import deploy_plugin
 
@@ -239,3 +241,25 @@ def test_append_indices(client: Steamship):
     assert file.blocks[0].text == "first"
     assert file.blocks[1].index_in_file == 1
     assert file.blocks[1].text == "second"
+
+
+@pytest.mark.usefixtures("client")
+def test_file_create_from_resp(client: Steamship):
+    class FakeSession:
+        def post(self, url: str, **kwargs):
+            resp = requests.Response()
+            resp.status_code = 200
+            resp.headers = {"Content-Type": "application/text"}
+            resp.raw = io.BytesIO(bytes("<html>you done goofed</html>", "utf-8"))
+            return resp
+
+    client._session = FakeSession()
+
+    with pytest.raises(SteamshipError) as err:
+        # the content here is not relevant to the test
+        # this should raise a SteamshipError complaining about expectations.
+        File.create(
+            client=client, blocks=[Block(text="/usr/bin/python root.py")], mime_type=MimeTypes.TXT
+        )
+
+    assert "data does not match expected" in str(err)


### PR DESCRIPTION
Steamship should be a good 🚢 . A good ship should not lie to users. It would be a lie to tell a user that a File was created when the object returned is not a File. Hence, Steamship must enforce expectations.

Without this PR, it is possible, though rare, for the following to happen:

```
f = File.create(client=client, blocks=[Block(text="something filtered by WAF")])
print(f.handle)
```

```
steamship.base.error.SteamshipError: ... | 'str' object has no attribute 'handle'
```