### PR TITLE
Move client error check to end, so that SteamshipErrors are processed…

### DIFF
--- a/src/steamship/base/client.py
+++ b/src/steamship/base/client.py
@@ -455,11 +455,6 @@ class Client(CamelModel, ABC):
 
         response_data = self._response_data(resp, raw_response=raw_response)
 
-        if not resp.ok:
-            raise SteamshipError(
-                f"API call did not complete successfully.  Server returned: {response_data}"
-            )
-
         logging.debug(f"Response JSON {response_data}")
 
         task = None
@@ -513,6 +508,11 @@ class Client(CamelModel, ABC):
         if error is not None:
             logging.warning(f"Client received error from server: {error}", exc_info=error)
             raise error
+
+        if not resp.ok:
+            raise SteamshipError(
+                f"API call did not complete successfully.  Server returned: {response_data}"
+            )
 
         elif task is not None:
             return task


### PR DESCRIPTION
… more nicely

When I added the fix the other day to make sure 403s were caught and processed as errors, I did it in a way that short-circuited the content processing of error cases.  This PR moves that check to the end of the method as a last resort.