### PR TITLE
Rehydrate Blocks with a client object in generators

### DIFF
--- a/src/steamship/plugin/generator.py
+++ b/src/steamship/plugin/generator.py
@@ -31,7 +31,10 @@ class Generator(PluginService[RawBlockAndTagPluginInput, RawBlockAndTagPluginOut
     @post("generate")
     def run_endpoint(self, **kwargs) -> InvocableResponse[RawBlockAndTagPluginOutput]:
         """Exposes the Tagger's `run` operation to the Steamship Engine via the expected HTTP path POST /tag"""
-        return self.run(PluginRequest[RawBlockAndTagPluginInput].parse_obj(kwargs))
+        input = PluginRequest[RawBlockAndTagPluginInput].parse_obj(kwargs)
+        for block in input.data.blocks:
+            block.client = self.client
+        return self.run(input)
 
 
 class TrainableGenerator(

--- a/tests/assets/plugins/generators/test_image_to_text_generator.py
+++ b/tests/assets/plugins/generators/test_image_to_text_generator.py
@@ -1,0 +1,22 @@
+from steamship import Block, MimeTypes
+from steamship.invocable import InvocableResponse
+from steamship.plugin.generator import Generator
+from steamship.plugin.inputs.raw_block_and_tag_plugin_input import RawBlockAndTagPluginInput
+from steamship.plugin.outputs.raw_block_and_tag_plugin_output import RawBlockAndTagPluginOutput
+from steamship.plugin.request import PluginRequest
+
+
+class TestGenerator(Generator):
+    def run(
+        self, request: PluginRequest[RawBlockAndTagPluginInput]
+    ) -> InvocableResponse[RawBlockAndTagPluginOutput]:
+        image_blocks = 0
+        fetched_raw = 0
+        for block in request.data.blocks:
+            if block.mime_type == MimeTypes.PNG:
+                image_blocks += 1
+                _ = block.raw()
+                fetched_raw += 1
+
+        output_text = f"Found {image_blocks} image blocks and fetched data from {fetched_raw}"
+        return InvocableResponse(data=RawBlockAndTagPluginOutput(blocks=[Block(text=output_text)]))


### PR DESCRIPTION
Not sure if there's a more general solution for this, but to be able to call `block.raw()` from within a generator, you need to have the block have a `client`.  

