### PR TITLE
feat: add paging to list operations in client SDK

### DIFF
--- a/src/steamship/base/request.py
+++ b/src/steamship/base/request.py
@@ -1,3 +1,6 @@
+from enum import Enum
+from typing import Optional
+
 from steamship.base.model import CamelModel
 
 
@@ -25,8 +28,15 @@ class IdentifierRequest(Request):
     handle: str = None
 
 
+class SortOrder(str, Enum):
+    ASC = "ASC"
+    DESC = "DESC"
+
+
 class ListRequest(Request):
-    pass
+    page_size: Optional[int]
+    page_token: Optional[str]
+    sort_order: Optional[SortOrder] = SortOrder.DESC
 
 
 class DeleteRequest(Request):

--- a/src/steamship/base/response.py
+++ b/src/steamship/base/response.py
@@ -1,5 +1,11 @@
+from typing import Optional
+
 from steamship.base.model import CamelModel
 
 
 class Response(CamelModel):
     pass
+
+
+class ListResponse(Response):
+    next_page_token: Optional[str]

--- a/src/steamship/base/tasks.py
+++ b/src/steamship/base/tasks.py
@@ -7,8 +7,10 @@ from pydantic import BaseModel, Field
 
 from steamship.base.error import SteamshipError
 from steamship.base.model import CamelModel, GenericCamelModel
-from steamship.base.request import DeleteRequest, IdentifierRequest, Request
+from steamship.base.request import DeleteRequest, IdentifierRequest, ListRequest, Request, SortOrder
 from steamship.utils.metadata import metadata_to_str, str_to_metadata
+
+from .response import ListResponse
 
 T = TypeVar("T")
 
@@ -21,7 +23,7 @@ class CreateTaskCommentRequest(Request):
     metadata: str = None
 
 
-class ListTaskCommentRequest(Request):
+class ListTaskCommentRequest(ListRequest):
     task_id: str = None
     external_id: str = None
     external_type: str = None
@@ -78,12 +80,18 @@ class TaskComment(CamelModel):
         external_id: str = None,
         external_type: str = None,
         external_group: str = None,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None,
+        sort_order: Optional[SortOrder] = SortOrder.DESC,
     ) -> TaskCommentList:
         req = ListTaskCommentRequest(
             taskId=task_id,
             external_id=external_id,
             external_type=external_type,
             externalGroup=external_group,
+            page_size=page_size,
+            page_token=page_token,
+            sort_order=sort_order,
         )
         return client.post(
             "task/comment/list",
@@ -100,7 +108,7 @@ class TaskComment(CamelModel):
         )
 
 
-class TaskCommentList(CamelModel):
+class TaskCommentList(ListResponse):
     comments: List[TaskComment]
 
 

--- a/src/steamship/data/embeddings.py
+++ b/src/steamship/data/embeddings.py
@@ -9,8 +9,8 @@ from steamship import SteamshipError
 from steamship.base import Task
 from steamship.base.client import Client
 from steamship.base.model import CamelModel
-from steamship.base.request import DeleteRequest, Request
-from steamship.base.response import Response
+from steamship.base.request import DeleteRequest, ListRequest, Request, SortOrder
+from steamship.base.response import ListResponse, Response
 from steamship.data.search import Hit
 from steamship.utils.metadata import metadata_to_str
 
@@ -113,14 +113,14 @@ class IndexSearchRequest(Request):
     include_metadata: bool = False
 
 
-class ListItemsRequest(Request):
+class ListItemsRequest(ListRequest):
     id: str = None
     file_id: str = None
     block_id: str = None
     span_id: str = None
 
 
-class ListItemsResponse(Response):
+class ListItemsResponse(ListResponse):
     items: List[EmbeddedItem]
 
 
@@ -259,8 +259,19 @@ class EmbeddingIndex(CamelModel):
         file_id: str = None,
         block_id: str = None,
         span_id: str = None,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None,
+        sort_order: Optional[SortOrder] = SortOrder.DESC,
     ) -> ListItemsResponse:
-        req = ListItemsRequest(id=self.id, file_id=file_id, block_id=block_id, spanId=span_id)
+        req = ListItemsRequest(
+            id=self.id,
+            file_id=file_id,
+            block_id=block_id,
+            spanId=span_id,
+            page_size=page_size,
+            page_token=page_token,
+            sort_order=sort_order,
+        )
         return self.client.post(
             "embedding-index/item/list",
             req,

--- a/src/steamship/data/file.py
+++ b/src/steamship/data/file.py
@@ -9,8 +9,8 @@ from pydantic import BaseModel, Field
 from steamship import MimeTypes, SteamshipError
 from steamship.base.client import Client
 from steamship.base.model import CamelModel
-from steamship.base.request import GetRequest, IdentifierRequest, Request
-from steamship.base.response import Response
+from steamship.base.request import GetRequest, IdentifierRequest, ListRequest, Request, SortOrder
+from steamship.base.response import ListResponse, Response
 from steamship.base.tasks import Task
 from steamship.data.block import Block
 from steamship.data.embeddings import EmbeddingIndex
@@ -31,11 +31,11 @@ class FileClearResponse(Response):
     id: str
 
 
-class ListFileRequest(Request):
+class ListFileRequest(ListRequest):
     pass
 
 
-class ListFileResponse(Response):
+class ListFileResponse(ListResponse):
     files: List[File]
 
 
@@ -249,10 +249,15 @@ class File(CamelModel):
         return plugin_instance.insert(tags)
 
     @staticmethod
-    def list(client: Client) -> ListFileResponse:
+    def list(
+        client: Client,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None,
+        sort_order: Optional[SortOrder] = SortOrder.DESC,
+    ) -> ListFileResponse:
         return client.post(
             "file/list",
-            ListFileRequest(),
+            ListFileRequest(pageSize=page_size, pageToken=page_token, sortOrder=sort_order),
             expect=ListFileResponse,
         )
 

--- a/src/steamship/data/plugin/plugin.py
+++ b/src/steamship/data/plugin/plugin.py
@@ -15,8 +15,8 @@ from pydantic import BaseModel, Field
 
 from steamship.base.client import Client
 from steamship.base.model import CamelModel
-from steamship.base.request import IdentifierRequest, Request, UpdateRequest
-from steamship.base.response import Response
+from steamship.base.request import IdentifierRequest, ListRequest, Request, SortOrder, UpdateRequest
+from steamship.base.response import ListResponse
 from steamship.data.manifest import Manifest
 
 from .hosting import HostingType
@@ -42,11 +42,11 @@ class PluginUpdateRequest(UpdateRequest):
     readme: Optional[str] = None
 
 
-class ListPluginsRequest(Request):
+class ListPluginsRequest(ListRequest):
     type: Optional[str] = None
 
 
-class ListPluginsResponse(Response):
+class ListPluginsResponse(ListResponse):
     plugins: List[Plugin]
 
 
@@ -122,10 +122,18 @@ class Plugin(CamelModel):
         )
 
     @staticmethod
-    def list(client: Client, t: str = None) -> ListPluginsResponse:
+    def list(
+        client: Client,
+        t: str = None,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None,
+        sort_order: Optional[SortOrder] = SortOrder.DESC,
+    ) -> ListPluginsResponse:
         return client.post(
             "plugin/list",
-            ListPluginsRequest(type=t),
+            ListPluginsRequest(
+                type=t, page_size=page_size, page_token=page_token, sort_order=sort_order
+            ),
             expect=ListPluginsResponse,
         )
 

--- a/src/steamship/data/workspace.py
+++ b/src/steamship/data/workspace.py
@@ -8,18 +8,18 @@ from pydantic import BaseModel, Field
 
 from steamship.base.client import Client
 from steamship.base.model import CamelModel
-from steamship.base.request import GetRequest, IdentifierRequest
-from steamship.base.request import Request
+from steamship.base.request import GetRequest, IdentifierRequest, ListRequest
 from steamship.base.request import Request as SteamshipRequest
-from steamship.base.response import Response
+from steamship.base.request import SortOrder
+from steamship.base.response import ListResponse
 from steamship.base.response import Response as SteamshipResponse
 
 
-class ListWorkspacesRequest(Request):
+class ListWorkspacesRequest(ListRequest):
     pass
 
 
-class ListWorkspacesResponse(Response):
+class ListWorkspacesResponse(ListResponse):
     workspaces: List[Workspace]
 
 
@@ -79,10 +79,18 @@ class Workspace(CamelModel):
         return ret
 
     @staticmethod
-    def list(client: Client, t: str = None) -> ListWorkspacesResponse:
+    def list(
+        client: Client,
+        t: str = None,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None,
+        sort_order: Optional[SortOrder] = SortOrder.DESC,
+    ) -> ListWorkspacesResponse:
         return client.post(
             "workspace/list",
-            ListWorkspacesRequest(type=t),
+            ListWorkspacesRequest(
+                type=t, page_size=page_size, page_token=page_token, sort_order=sort_order
+            ),
             expect=ListWorkspacesResponse,
         )
 

--- a/tests/steamship_tests/data/test_file.py
+++ b/tests/steamship_tests/data/test_file.py
@@ -8,6 +8,7 @@ from steamship_tests import PLUGINS_PATH
 from steamship_tests.utils.deployables import deploy_plugin
 
 from steamship import MimeTypes, SteamshipError
+from steamship.base.request import SortOrder
 from steamship.client import Steamship
 from steamship.data.block import Block
 from steamship.data.file import File
@@ -206,6 +207,51 @@ def test_file_list(client: Steamship):
     assert a in files
     assert b in files
     assert c in files
+
+    a.delete()
+    b.delete()
+    c.delete()
+
+
+def test_file_list_paging(client: Steamship):
+    a = File.create(
+        client=client,
+        tags=[Tag(kind="FileTag", value={"name": "A"})],
+    )
+    b = File.create(
+        client=client,
+        tags=[Tag(kind="FileTag", value={"name": "B"})],
+    )
+    c = File.create(
+        client=client,
+        tags=[Tag(kind="FileTag", value={"name": "C"})],
+    )
+
+    page_size = 1
+    resp = File.list(client=client, page_size=page_size)
+    assert len(resp.files) == page_size
+    assert resp.next_page_token is not None
+    assert c == resp.files[0]  # default is DESC (createdAt)
+
+    resp = File.list(client=client, page_size=page_size, page_token=resp.next_page_token)
+    assert len(resp.files) == page_size
+    assert resp.next_page_token is not None
+    assert b == resp.files[0]
+
+    resp = File.list(client=client, page_size=page_size, page_token=resp.next_page_token)
+    assert len(resp.files) == page_size
+    assert resp.next_page_token is None
+    assert a == resp.files[0]
+
+    files = File.list(client=client, page_size=page_size, sort_order=SortOrder.ASC).files
+    assert len(files) == 1
+    assert files[0] == a
+
+    with pytest.raises(SteamshipError):
+        File.list(client=client, page_size=-1)
+
+    resp = File.list(client=client, page_token="not-found-foo")  # noqa: S106
+    assert len(resp.files) == 3
 
     a.delete()
     b.delete()

--- a/tests/steamship_tests/data/test_plugins.py
+++ b/tests/steamship_tests/data/test_plugins.py
@@ -147,3 +147,28 @@ def test_plugin_instance_handle_refs():
     use_instance = steamship.use_plugin("test-tagger", handle)
     assert use_instance.plugin_handle == "test-tagger"
     assert use_instance.plugin_version_handle == "1.0"
+
+
+def test_plugin_list_paging():
+    steamship = get_steamship_client()
+
+    resp = Plugin.list(steamship)
+    orig_count = len(resp.plugins)
+
+    Plugin.create(
+        client=steamship,
+        description="This is just for testing list",
+        type_=PluginType.tagger,
+        transport=PluginAdapterType.steamship_docker,
+        is_public=False,
+    )
+    resp = Plugin.list(steamship)
+    assert len(resp.plugins) == orig_count + 1
+
+    resp = Plugin.list(steamship, page_size=1)
+    assert len(resp.plugins) == 1
+    if orig_count > 0:
+        assert resp.next_page_token is not None
+    else:
+        assert resp.next_page_token is None
+    assert resp.plugins[0].description == "This is just for testing list"

--- a/tests/steamship_tests/data/test_plugins.py
+++ b/tests/steamship_tests/data/test_plugins.py
@@ -12,8 +12,8 @@ from steamship.data.user import User
 def test_plugin_create():
     steamship = get_steamship_client()
 
-    my_plugins = Plugin.list(steamship)
-    orig_count = len(my_plugins.plugins)
+    resp = Plugin.list(steamship)
+    prior_plugin_ids = [plugin.id for plugin in resp.plugins]
 
     plugin_args = {
         "client": steamship,
@@ -29,9 +29,6 @@ def test_plugin_create():
         with pytest.raises(TypeError):
             Plugin.create(**plugin_args)
 
-    my_plugins = Plugin.list(steamship)
-    assert len(my_plugins.plugins) == orig_count
-
     plugin = Plugin.create(
         client=steamship,
         description="This is just for test",
@@ -39,8 +36,17 @@ def test_plugin_create():
         transport=PluginAdapterType.steamship_docker,
         is_public=False,
     )
-    my_plugins = Plugin.list(steamship)
-    assert len(my_plugins.plugins) == orig_count + 1
+
+    assert plugin.id not in prior_plugin_ids
+
+    resp = Plugin.list(steamship)
+    assert plugin.id in [
+        plugin.id for plugin in resp.plugins
+    ]  # newly-created plugin should be top of list
+    assert plugin.description in [plugin.description for plugin in resp.plugins]
+
+    user_id = User.current(steamship).id
+    assert plugin.user_id == user_id
 
     # No fetch_if_exists doesn't work
     with pytest.raises(SteamshipError):
@@ -52,17 +58,6 @@ def test_plugin_create():
             transport=PluginAdapterType.steamship_docker,
             is_public=False,
         )
-
-    my_plugins = Plugin.list(steamship)
-    assert len(my_plugins.plugins) == orig_count + 1
-
-    assert plugin.id in [plugin.id for plugin in my_plugins.plugins]
-    assert plugin.description in [plugin.description for plugin in my_plugins.plugins]
-
-    user_id = User.current(steamship).id
-    assert plugin.user_id == user_id
-
-    # assert(my_plugins.plugins[0].description != plugin.description)
 
 
 def test_plugin_public():
@@ -147,28 +142,3 @@ def test_plugin_instance_handle_refs():
     use_instance = steamship.use_plugin("test-tagger", handle)
     assert use_instance.plugin_handle == "test-tagger"
     assert use_instance.plugin_version_handle == "1.0"
-
-
-def test_plugin_list_paging():
-    steamship = get_steamship_client()
-
-    resp = Plugin.list(steamship)
-    orig_count = len(resp.plugins)
-
-    Plugin.create(
-        client=steamship,
-        description="This is just for testing list",
-        type_=PluginType.tagger,
-        transport=PluginAdapterType.steamship_docker,
-        is_public=False,
-    )
-    resp = Plugin.list(steamship)
-    assert len(resp.plugins) == orig_count + 1
-
-    resp = Plugin.list(steamship, page_size=1)
-    assert len(resp.plugins) == 1
-    if orig_count > 0:
-        assert resp.next_page_token is not None
-    else:
-        assert resp.next_page_token is None
-    assert resp.plugins[0].description == "This is just for testing list"


### PR DESCRIPTION
Companion PR to https://github.com/nludb/nludb/pull/483.

This adds support for paging in the python SDK for objects that support a `list` call currently.