### PR TITLE
feat: add owner and workspace handles to invocation context

### DIFF
--- a/src/steamship/invocable/invocable_request.py
+++ b/src/steamship/invocable/invocable_request.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from steamship.base import Configuration
 from steamship.base.model import CamelModel
@@ -28,6 +28,8 @@ class InvocationContext(CamelModel):
     invocable_type: str = None
     invocable_owner_id: str = None
     invocable_url: str = None
+    invocable_owner_handle: Optional[str] = None
+    workspace_handle: Optional[str] = None
 
 
 class InvocableRequest(CamelModel):


### PR DESCRIPTION
Companion PR to: https://github.com/nludb/nludb/pull/535

The idea is to allow packages to dynamically provide manifests that use their domain-specific invocation URL.

Concerns:
- Exposes user workspace handles to owners
- Exposes owner handles to users
