### PR TITLE
fix: collab support

### DIFF
--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -111,13 +111,13 @@ class Invocable(ABC):
 
         try:
             secret_kwargs = toml.load(".steamship/secrets.toml")
-        except FileNotFoundError:  # Support local secret loading
+        except OSError:  # Support local secret loading
             try:
                 local_secrets_file = (
                     pathlib.Path(inspect.getfile(type(self))).parent / ".steamship" / "secrets.toml"
                 )
                 secret_kwargs = toml.load(str(local_secrets_file))
-            except (TypeError, FileNotFoundError):
+            except (TypeError, OSError):  # Support collab usage
                 secret_kwargs = {}
 
         # The configuration for the Invocable is the union of:


### PR DESCRIPTION
Without this PR, attempting to run the collab script linked from our website (https://colab.research.google.com/drive/1r-LkB1vgbc6LHpK0MiDWLl0_jU2nSw50#scrollTo=L_5kDYuh5YWg) results in the following:

```
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
[/usr/local/lib/python3.10/dist-packages/steamship/invocable/invocable.py](https://localhost:8080/#) in __init__(self, client, config, context)
    112         try:
--> 113             secret_kwargs = toml.load(".steamship/secrets.toml")
    114         except FileNotFoundError:  # Support local secret loading

4 frames
FileNotFoundError: [Errno 2] No such file or directory: '.steamship/secrets.toml'

During handling of the above exception, another exception occurred:

OSError                                   Traceback (most recent call last)
[/usr/lib/python3.10/inspect.py](https://localhost:8080/#) in getfile(object)
    783                 return module.__file__
    784             if object.__module__ == '__main__':
--> 785                 raise OSError('source code not available')
    786         raise TypeError('{!r} is a built-in class'.format(object))
    787     if ismethod(object):

OSError: source code not available
```

This PR adopts the superclass of FileNotFound (OSError).