### PR TITLE
On generator return, only rewrite blocks if the result has data

### DIFF
--- a/src/steamship/plugin/generator.py
+++ b/src/steamship/plugin/generator.py
@@ -42,13 +42,14 @@ class Generator(PluginService[RawBlockAndTagPluginInput, RawBlockAndTagPluginOut
         result = self.run(input)
 
         # Rewrite block output by changing any blocks with byte content to pass by URL
-        result_blocks = []
-        for block in result.data.blocks:
-            if block.upload_type == BlockUploadType.FILE:
-                result_blocks.append(self.upload_block_content_to_signed_url(block))
-            else:
-                result_blocks.append(block)
-        result.data.blocks = result_blocks
+        if result.data is not None and result.data.blocks is not None:
+            result_blocks = []
+            for block in result.data.blocks:
+                if block.upload_type == BlockUploadType.FILE:
+                    result_blocks.append(self.upload_block_content_to_signed_url(block))
+                else:
+                    result_blocks.append(block)
+            result.data.blocks = result_blocks
         return result
 
     def upload_block_content_to_signed_url(self, block: Block) -> Block:


### PR DESCRIPTION
Currently, it's not possible to write an async generator plugin, because the shim code in generator.py attempts to rewrite data.  In the async case, where data is not yet filled, this will throw an error.

This PR adds a condition so that the blocks are only rewritten if data is present.