### PR TITLE
Bugfix: Double instance_init

### DIFF
--- a/src/steamship/invocable/lambda_handler.py
+++ b/src/steamship/invocable/lambda_handler.py
@@ -82,7 +82,7 @@ def internal_handler(  # noqa: C901
         if call_instance_init:
             # TODO: We don't want to run this every time, but for now we are.
             logging.info("Running __instance_init__")
-        invocable.instance_init()
+            invocable.instance_init()
     except SteamshipError as se:
         logging.exception(se)
         return InvocableResponse.from_obj(se)


### PR DESCRIPTION
In merging the handler and local_handler code in #343 , I accidentally introduced an issue where instance init was being called once per invocation even when deployed to lambda.  This change should fix.