### PR TITLE
Make parse inbound returns optional

### DIFF
--- a/src/steamship/experimental/package_starters/telegram_bot.py
+++ b/src/steamship/experimental/package_starters/telegram_bot.py
@@ -44,9 +44,13 @@ class TelegramBot(SteamshipWidgetBot, ABC):
         chat_id = message.get("chat", {}).get("id")
         try:
             incoming_message = self.telegram_transport.parse_inbound(message)
-            response = self.create_response(incoming_message)
-            if response is not None:
-                self.telegram_transport.send(response)
+            if incoming_message is not None:
+                response = self.create_response(incoming_message)
+                if response is not None:
+                    self.telegram_transport.send(response)
+                else:
+                    # Do nothing here; this could be a message we intentionally don't want to respond to (ex. an image or file upload)
+                    pass
             else:
                 # Do nothing here; this could be a message we intentionally don't want to respond to (ex. an image or file upload)
                 pass

--- a/src/steamship/experimental/transports/steamship_widget.py
+++ b/src/steamship/experimental/transports/steamship_widget.py
@@ -29,7 +29,9 @@ class SteamshipWidgetTransport(Transport):
         """Fetches info about this bot."""
         return {}
 
-    def _parse_inbound(self, payload: dict, context: Optional[dict] = None) -> ChatMessage:
+    def _parse_inbound(
+        self, payload: dict, context: Optional[dict] = None
+    ) -> Optional[ChatMessage]:
         """Parses an inbound Steamship widget message."""
 
         message_text = payload.get("question")

--- a/src/steamship/experimental/transports/transport.py
+++ b/src/steamship/experimental/transports/transport.py
@@ -72,11 +72,13 @@ class Transport(ABC):
     def _send(self, blocks: List[ChatMessage]):
         raise NotImplementedError
 
-    def parse_inbound(self, payload: dict, context: Optional[dict] = None) -> ChatMessage:
+    def parse_inbound(self, payload: dict, context: Optional[dict] = None) -> Optional[ChatMessage]:
         return self._parse_inbound(payload, context)
 
     @abstractmethod
-    def _parse_inbound(self, payload: dict, context: Optional[dict] = None) -> ChatMessage:
+    def _parse_inbound(
+        self, payload: dict, context: Optional[dict] = None
+    ) -> Optional[ChatMessage]:
         raise NotImplementedError
 
     def info(self) -> dict:


### PR DESCRIPTION
If the telegram bot joins a group, or receives an image, it gets a message with no text value.  Rather than this throwing an error in parse_inbound, we return None, so that the bot can decide not to reply without try/except.