### PR TITLE
Fix web-bot

### DIFF
--- a/src/steamship/experimental/package_starters/telegram_bot.py
+++ b/src/steamship/experimental/package_starters/telegram_bot.py
@@ -5,7 +5,10 @@ from typing import Type
 import requests
 from pydantic import Field
 
-from steamship.experimental.package_starters.web_bot import SteamshipWidgetBot
+from steamship.experimental.package_starters.web_bot import (
+    SteamshipWidgetBot,
+    response_for_exception,
+)
 from steamship.experimental.transports import TelegramTransport
 from steamship.invocable import Config, InvocableResponse, post
 
@@ -15,7 +18,6 @@ class TelegramBotConfig(Config):
 
 
 class TelegramBot(SteamshipWidgetBot, ABC):
-
     config: TelegramBotConfig
     telegram_transport: TelegramTransport
 
@@ -51,7 +53,7 @@ class TelegramBot(SteamshipWidgetBot, ABC):
                 # Do nothing here; this could be a message we intentionally don't want to respond to (ex. an image or file upload)
                 pass
         except Exception as e:
-            response = self.response_for_exception(e, chat_id=chat_id)
+            response = response_for_exception(e, chat_id=chat_id)
 
             if chat_id is not None:
                 self.telegram_transport.send([response])

--- a/src/steamship/experimental/package_starters/web_bot.py
+++ b/src/steamship/experimental/package_starters/web_bot.py
@@ -1,14 +1,23 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
-from steamship import Block
 from steamship.experimental.transports.chat import ChatMessage
 from steamship.experimental.transports.steamship_widget import SteamshipWidgetTransport
 from steamship.invocable import PackageService, post
 
 
-class SteamshipWidgetBot(PackageService, ABC):
+def response_for_exception(e: Optional[Exception], chat_id: Optional[str] = None) -> ChatMessage:
+    return_text = f"An error happened while creating a response: {e}"
+    if e is None:
+        return_text = "An unknown error happened. Please reach out to support@steamship.com or on our discord at https://steamship.com/discord"
 
+    if "usage limit" in f"{e}":
+        return_text = "You have reached the introductory limit of Steamship. Visit https://steamship.com/account/plan to sign up for a plan."
+
+    return ChatMessage(chat_id=chat_id, text=return_text)
+
+
+class SteamshipWidgetBot(PackageService, ABC):
     steamship_widget_transport: SteamshipWidgetTransport
 
     def __init__(self, **kwargs):
@@ -20,28 +29,13 @@ class SteamshipWidgetBot(PackageService, ABC):
         raise NotImplementedError
 
     @post("answer", public=True)
-    def answer(self, **payload) -> Dict[str, Any]:
+    def answer(self, **payload) -> List[ChatMessage]:
         """Endpoint that implements the contract for Steamship embeddable chat widgets. This is a PUBLIC endpoint since these webhooks do not pass a token."""
         incoming_message = self.steamship_widget_transport.parse_inbound(payload)
-        response = self.create_response(incoming_message)
-        if response is None:
-            response = [Block(text="Bot returned no response.")]
+        try:
+            response = self.create_response(incoming_message)
+        except Exception as e:
+            response = response_for_exception(e, chat_id=incoming_message.get_chat_id())
 
         # We don't call self.steamship_widget_transport.send because the result is the return value
-        return {
-            "answer": [block.dict(by_alias=True) for block in response],
-            "sources": [],
-            "is_plausible": True,
-        }
-
-    def response_for_exception(
-        self, e: Optional[Exception], chat_id: Optional[str] = None
-    ) -> ChatMessage:
-        return_text = f"An error happened while creating a response: {e}"
-        if e is None:
-            return_text = "An unknown error happened. Please reach out to support@steamship.com or on our discord at https://steamship.com/discord"
-
-        if "usage limit" in f"{e}":
-            return_text = "You have reached the introductory limit of Steamship. Visit https://steamship.com/account/plan to sign up for a plan."
-
-        return ChatMessage(chat_id=chat_id, text=return_text)
+        return response

--- a/src/steamship/experimental/transports/chat.py
+++ b/src/steamship/experimental/transports/chat.py
@@ -6,6 +6,9 @@ from steamship.experimental.easy.tags import get_tag_value_key
 
 
 class ChatMessage(Block):
+
+    who: Optional[str] = "bot"
+
     def __init__(self, chat_id: Optional[str] = None, message_id: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
 


### PR DESCRIPTION
This PR makes the response format of the webbot compatible with what is currently supported by the front end.  

<img width="743" alt="image" src="https://github.com/steamship-core/python-client/assets/13366849/2fae5577-7311-42c7-843d-96db9d892a99">


I also added the field `who` to ChatMessage so we wouldn't need a hacky way to include that field in our response (by default we ignore fields that aren't defined in the spec). For context, here's how the hackathon project added the who field: 

<img width="399" alt="image" src="https://github.com/steamship-core/python-client/assets/13366849/4a4f28d0-44d2-4f97-8e8e-23c21b94742e">
 


🚨 This PR temporarily removes support for source attribution. This will be added back in a follow-up PR to decide if and how sources fit into ChatMessage responses. 
