### PR TITLE
Proposal to add sources to ChatMessage

### DIFF
--- a/src/steamship/experimental/transports/chat.py
+++ b/src/steamship/experimental/transports/chat.py
@@ -1,13 +1,25 @@
-from typing import Optional
+from typing import List, Optional
+
+from pydantic import Field
 
 from steamship import Block, SteamshipError, Tag
+from steamship.base.model import CamelModel
 from steamship.data.tags.tag_constants import ChatTag, DocTag, TagValueKey
 from steamship.experimental.easy.tags import get_tag_value_key
 
 
-class ChatMessage(Block):
+class Document(CamelModel):
+    """Interface for interacting with a document."""
 
+    page_content: str
+    lookup_str: str = ""
+    lookup_index = 0
+    metadata: dict = Field(default_factory=dict)
+
+
+class ChatMessage(Block):
     who: Optional[str] = "bot"
+    sources: Optional[List[Document]] = Field(default_factory=list)
 
     def __init__(self, chat_id: Optional[str] = None, message_id: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)

--- a/src/steamship/experimental/transports/chat.py
+++ b/src/steamship/experimental/transports/chat.py
@@ -12,8 +12,6 @@ class Document(CamelModel):
     """Interface for interacting with a document."""
 
     page_content: str
-    lookup_str: str = ""
-    lookup_index = 0
     metadata: dict = Field(default_factory=dict)
 
 


### PR DESCRIPTION
This PR adds sources to ChatMessage so the Q&A agent can include sources in its response. 

I introduced a definition of Document which is compatible with LangChain so we can easily upgrade our existing q&a agents. 

We can easily extend/change the definition of a source document once we have a better view on our agents and docstore. 