### PR TITLE
feat: AgentService & Action Interface Stubs

### DIFF
--- a/src/steamship/agents/action.py
+++ b/src/steamship/agents/action.py
@@ -1,0 +1,36 @@
+import abc
+from typing import List
+
+from pydantic import BaseModel
+
+from steamship import Block
+
+
+@abc.ABC
+class Action(BaseModel):
+    pass
+
+
+class SpeakAction(Action):
+    """Represents saying something to the chat."""
+
+    messages: List[Block]
+
+
+class ToolAction(Action):
+    """Represents the invocation of a Tool."""
+
+    tool_name: str
+    tool_input: List[Block]
+
+
+class NoOpAction(Action):
+    """Represents no action."""
+
+    pass
+
+
+class FinishAction(Action):
+    """Represents the cessasation of auto-reasoning loop."""
+
+    messages: List[Block]

--- a/src/steamship/invocable/agent_service.py
+++ b/src/steamship/invocable/agent_service.py
@@ -1,0 +1,47 @@
+from argparse import Action
+
+from steamship import SteamshipError
+from steamship.agents.action import NoOpAction
+from steamship.agents.context import AgentContext
+from steamship.invocable import PackageService, post
+
+
+class AgentService(PackageService):
+
+    # Internal Methods
+    # ------------------------------------------------------------------------------------------------------------
+
+    def _get_context(self) -> AgentContext:
+        return AgentContext()
+
+    def _decide_next_action(self, context: AgentContext) -> Action:
+        """Decides upon the next action synchronously, given the available context."""
+        return NoOpAction()
+
+    def _perform_action(self, action: Action, context: AgentContext) -> Action:
+        """Performs an Action"""
+        if isinstance(action, NoOpAction):
+            return action
+
+        raise SteamshipError(message=f"I do not yet know how to take action: {action}")
+
+    # API Methods
+    # ------------------------------------------------------------------------------------------------------------
+
+    @post("perform_next_action")
+    def perform_next_action(self) -> Action:
+        """Decides upon, and then performs, the next appropriate Action."""
+        context = self._get_context()
+        next_action = self._decide_next_action(context)
+        result = self._perform_action(next_action, context)
+        return result
+
+    @post("run")
+    def run(self, maximum_steps: int = 20) -> Action:
+        """Enters a loop in which reasoning and action performance occurs.
+
+        This loop will terminate:
+        - When the FinishAction is emitted.
+        - When maximum_steps have arisen.
+        """
+        raise NotImplementedError()


### PR DESCRIPTION
This PR collects a few bare-bones common elements of @EniasCailliau and @douglas-reid's agent WIP PRs. 

The goal is to nail down an incredibly simplistic set of base classes that appear to be in common across all threads of prototyping, so that we increase the surface area of shared dependency.

There are two decisions in this PR which might not be shared that I'll point out here; proposal is for us to Replit-hack together and then merge this PR in:

- `List[Block]` as the I/O format (as opposed to `str` or `Any` or `Block`)
- `SpeakAction` as a distinct action that's possible, even though `FinishAction` also has a `messages` field

