### PR TITLE
Update docs for agents

### DIFF
--- a/docs/agents/index.rst
+++ b/docs/agents/index.rst
@@ -7,7 +7,7 @@ Steamship is made for building, scaling, and managing Agents in the cloud.
 
 A full tutorial for getting started with Agents is available here:
 
-`Agent Tutorial <https://www.steamship.com/packages>`_
+`Agent Guidebook <https://www.steamship.com/learn/agent-guidebook>`_
 
 If you're new to building Agents, we highly recommend following the above tutorial.
 

--- a/docs/agents/index.rst
+++ b/docs/agents/index.rst
@@ -1,0 +1,59 @@
+.. _Building Agents:
+
+Agents
+======
+
+Steamship is made for building, scaling, and managing Agents in the cloud.
+
+A full tutorial for getting started with Agents is available here:
+
+`Agent Tutorial <https://www.steamship.com/packages>`_
+
+If you're new to building Agents, we highly recommend following the above tutorial.
+
+The following are pointers to the key Agent classes for getting started:
+
+Agent
+-----
+
+The basic interface for Agents is:
+
+:class:`steamship.agents.schema.agent.Agent`
+
+Implementations of this class make decisions about what Action will be taken next in an Agent workflow.
+
+AgentContext
+------------
+
+The Agent Context contains data about the context in which the Agent is running, including its
+ChatHistory.
+
+Tool
+----
+
+A Tool is something that an Agent may make use of in service of achieving its goal. To support multi-modal data,
+Tools in Steamship take an AgentContext as input and produce :ref:`Blocks` as output.
+
+Many tools are available pre-packaged within the SDK:
+
+- :class:`steamship.agents.tools.search.search.SearchTool`
+- :class:`steamship.agents.tools.speech_generation.generate_speech.GenerateSpeechTool` (via ElevenLabs)
+- :class:`steamship.agents.tools.image_generation.dalle.DalleTool`
+- :class:`steamship.agents.tools.image_generation.stable_diffusion.StableDiffusionTool`
+- ... and more in the ``steamship.agents.tools`` package.
+
+
+AgentService
+------------
+
+:class:`steamship.agents.service.agent_service.AgentService`
+
+The AgentService class provides a convenient way to deploy an Agent as a Steamship :ref:`Package<Packages>`.
+
+TelegramAgentService
+--------------------
+
+:class:`steamship.experimental.package_starters.telegram_agent.TelegramAgentService`
+The TelegramAgentService class connects your Agent with the Telegram Webhook API, allowing it to serve messages to Telegram users.
+
+

--- a/docs/api/steamship.agents.examples.rst
+++ b/docs/api/steamship.agents.examples.rst
@@ -1,0 +1,21 @@
+steamship.agents.examples package
+=================================
+
+Submodules
+----------
+
+steamship.agents.examples.my\_assistant module
+----------------------------------------------
+
+.. automodule:: steamship.agents.examples.my_assistant
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.examples
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.llms.rst
+++ b/docs/api/steamship.agents.llms.rst
@@ -1,0 +1,21 @@
+steamship.agents.llms package
+=============================
+
+Submodules
+----------
+
+steamship.agents.llms.openai module
+-----------------------------------
+
+.. automodule:: steamship.agents.llms.openai
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.llms
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.memory.rst
+++ b/docs/api/steamship.agents.memory.rst
@@ -1,0 +1,21 @@
+steamship.agents.memory package
+===============================
+
+Submodules
+----------
+
+steamship.agents.memory.chathistory module
+------------------------------------------
+
+.. automodule:: steamship.agents.memory.chathistory
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.memory
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.react.rst
+++ b/docs/api/steamship.agents.react.rst
@@ -1,0 +1,29 @@
+steamship.agents.react package
+==============================
+
+Submodules
+----------
+
+steamship.agents.react.output\_parser module
+--------------------------------------------
+
+.. automodule:: steamship.agents.react.output_parser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.react.react module
+-----------------------------------
+
+.. automodule:: steamship.agents.react.react
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.react
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.rst
+++ b/docs/api/steamship.agents.rst
@@ -1,0 +1,43 @@
+steamship.agents package
+========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   steamship.agents.examples
+   steamship.agents.llms
+   steamship.agents.memory
+   steamship.agents.react
+   steamship.agents.schema
+   steamship.agents.service
+   steamship.agents.tools
+
+Submodules
+----------
+
+steamship.agents.logging module
+-------------------------------
+
+.. automodule:: steamship.agents.logging
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.utils module
+-----------------------------
+
+.. automodule:: steamship.agents.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.schema.rst
+++ b/docs/api/steamship.agents.schema.rst
@@ -1,0 +1,61 @@
+steamship.agents.schema package
+===============================
+
+Submodules
+----------
+
+steamship.agents.schema.action module
+-------------------------------------
+
+.. automodule:: steamship.agents.schema.action
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.schema.agent module
+------------------------------------
+
+.. automodule:: steamship.agents.schema.agent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.schema.context module
+--------------------------------------
+
+.. automodule:: steamship.agents.schema.context
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.schema.llm module
+----------------------------------
+
+.. automodule:: steamship.agents.schema.llm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.schema.output\_parser module
+---------------------------------------------
+
+.. automodule:: steamship.agents.schema.output_parser
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.schema.tool module
+-----------------------------------
+
+.. automodule:: steamship.agents.schema.tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.schema
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.service.rst
+++ b/docs/api/steamship.agents.service.rst
@@ -1,0 +1,21 @@
+steamship.agents.service package
+================================
+
+Submodules
+----------
+
+steamship.agents.service.agent\_service module
+----------------------------------------------
+
+.. automodule:: steamship.agents.service.agent_service
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.service
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.tools.audio_transcription.rst
+++ b/docs/api/steamship.agents.tools.audio_transcription.rst
@@ -1,0 +1,37 @@
+steamship.agents.tools.audio\_transcription package
+===================================================
+
+Submodules
+----------
+
+steamship.agents.tools.audio\_transcription.assembly\_speech\_to\_text\_tool module
+-----------------------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.audio_transcription.assembly_speech_to_text_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.tools.audio\_transcription.fetch\_audio\_urls\_from\_rss\_tool module
+--------------------------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.audio_transcription.fetch_audio_urls_from_rss_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.tools.audio\_transcription.whisper\_speech\_to\_text\_tool module
+----------------------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.audio_transcription.whisper_speech_to_text_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.tools.audio_transcription
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.tools.classification.rst
+++ b/docs/api/steamship.agents.tools.classification.rst
@@ -1,0 +1,29 @@
+steamship.agents.tools.classification package
+=============================================
+
+Submodules
+----------
+
+steamship.agents.tools.classification.sentiment\_analysis\_tool module
+----------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.classification.sentiment_analysis_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.tools.classification.zero\_shot\_classifier\_tool module
+-------------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.classification.zero_shot_classifier_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.tools.classification
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.tools.conversation_starters.rst
+++ b/docs/api/steamship.agents.tools.conversation_starters.rst
@@ -1,0 +1,21 @@
+steamship.agents.tools.conversation\_starters package
+=====================================================
+
+Submodules
+----------
+
+steamship.agents.tools.conversation\_starters.knock\_knock\_tool module
+-----------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.conversation_starters.knock_knock_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.tools.conversation_starters
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.tools.image_generation.rst
+++ b/docs/api/steamship.agents.tools.image_generation.rst
@@ -1,0 +1,37 @@
+steamship.agents.tools.image\_generation package
+================================================
+
+Submodules
+----------
+
+steamship.agents.tools.image\_generation.dalle module
+-----------------------------------------------------
+
+.. automodule:: steamship.agents.tools.image_generation.dalle
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.tools.image\_generation.google\_image\_search module
+---------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.image_generation.google_image_search
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.tools.image\_generation.stable\_diffusion module
+-----------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.image_generation.stable_diffusion
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.tools.image_generation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.tools.question_answering.rst
+++ b/docs/api/steamship.agents.tools.question_answering.rst
@@ -1,0 +1,29 @@
+steamship.agents.tools.question\_answering package
+==================================================
+
+Submodules
+----------
+
+steamship.agents.tools.question\_answering.prompt\_database\_question\_answerer module
+--------------------------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.question_answering.prompt_database_question_answerer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.tools.question\_answering.vector\_search\_qa\_tool module
+--------------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.question_answering.vector_search_qa_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.tools.question_answering
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.tools.rst
+++ b/docs/api/steamship.agents.tools.rst
@@ -1,0 +1,36 @@
+steamship.agents.tools package
+==============================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   steamship.agents.tools.audio_transcription
+   steamship.agents.tools.classification
+   steamship.agents.tools.conversation_starters
+   steamship.agents.tools.image_generation
+   steamship.agents.tools.question_answering
+   steamship.agents.tools.search
+   steamship.agents.tools.speech_generation
+   steamship.agents.tools.text_generation
+
+Submodules
+----------
+
+steamship.agents.tools.base\_tools module
+-----------------------------------------
+
+.. automodule:: steamship.agents.tools.base_tools
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.tools
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.tools.search.rst
+++ b/docs/api/steamship.agents.tools.search.rst
@@ -1,0 +1,21 @@
+steamship.agents.tools.search package
+=====================================
+
+Submodules
+----------
+
+steamship.agents.tools.search.search module
+-------------------------------------------
+
+.. automodule:: steamship.agents.tools.search.search
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.tools.search
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.tools.speech_generation.rst
+++ b/docs/api/steamship.agents.tools.speech_generation.rst
@@ -1,0 +1,21 @@
+steamship.agents.tools.speech\_generation package
+=================================================
+
+Submodules
+----------
+
+steamship.agents.tools.speech\_generation.generate\_speech module
+-----------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.speech_generation.generate_speech
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.tools.speech_generation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.tools.text_generation.rst
+++ b/docs/api/steamship.agents.tools.text_generation.rst
@@ -1,0 +1,53 @@
+steamship.agents.tools.text\_generation package
+===============================================
+
+Submodules
+----------
+
+steamship.agents.tools.text\_generation.image\_prompt\_generator\_tool module
+-----------------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.text_generation.image_prompt_generator_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.tools.text\_generation.personality\_tool module
+----------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.text_generation.personality_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.tools.text\_generation.summarize\_text\_with\_prompt\_tool module
+----------------------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.text_generation.summarize_text_with_prompt_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.tools.text\_generation.text\_rewrite\_tool module
+------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.text_generation.text_rewrite_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.tools.text\_generation.text\_translation\_tool module
+----------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.text_generation.text_translation_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.tools.text_generation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.base.rst
+++ b/docs/api/steamship.base.rst
@@ -84,14 +84,6 @@ steamship.base.tasks module
    :undoc-members:
    :show-inheritance:
 
-steamship.base.utils module
----------------------------
-
-.. automodule:: steamship.base.utils
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 Module contents
 ---------------
 

--- a/docs/api/steamship.cli.local_server.rst
+++ b/docs/api/steamship.cli.local_server.rst
@@ -1,0 +1,29 @@
+steamship.cli.local\_server package
+===================================
+
+Submodules
+----------
+
+steamship.cli.local\_server.handler module
+------------------------------------------
+
+.. automodule:: steamship.cli.local_server.handler
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.cli.local\_server.server module
+-----------------------------------------
+
+.. automodule:: steamship.cli.local_server.server
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.cli.local_server
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.cli.rst
+++ b/docs/api/steamship.cli.rst
@@ -1,6 +1,14 @@
 steamship.cli package
 =====================
 
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   steamship.cli.local_server
+
 Submodules
 ----------
 
@@ -8,6 +16,14 @@ steamship.cli.cli module
 ------------------------
 
 .. automodule:: steamship.cli.cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.cli.create\_instance module
+-------------------------------------
+
+.. automodule:: steamship.cli.create_instance
    :members:
    :undoc-members:
    :show-inheritance:
@@ -48,6 +64,14 @@ steamship.cli.ship\_spinner module
 ----------------------------------
 
 .. automodule:: steamship.cli.ship_spinner
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.cli.utils module
+--------------------------
+
+.. automodule:: steamship.cli.utils
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/steamship.experimental.easy.rst
+++ b/docs/api/steamship.experimental.easy.rst
@@ -1,0 +1,37 @@
+steamship.experimental.easy package
+===================================
+
+Submodules
+----------
+
+steamship.experimental.easy.blockify module
+-------------------------------------------
+
+.. automodule:: steamship.experimental.easy.blockify
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.experimental.easy.scrape module
+-----------------------------------------
+
+.. automodule:: steamship.experimental.easy.scrape
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.experimental.easy.tags module
+---------------------------------------
+
+.. automodule:: steamship.experimental.easy.tags
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.experimental.easy
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.experimental.package_starters.rst
+++ b/docs/api/steamship.experimental.package_starters.rst
@@ -1,0 +1,39 @@
+steamship.experimental.package\_starters namespace
+==================================================
+
+.. py:module:: steamship.experimental.package_starters
+
+Submodules
+----------
+
+steamship.experimental.package\_starters.telegram\_agent module
+---------------------------------------------------------------
+
+.. automodule:: steamship.experimental.package_starters.telegram_agent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.experimental.package\_starters.telegram\_bot module
+-------------------------------------------------------------
+
+.. automodule:: steamship.experimental.package_starters.telegram_bot
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.experimental.package\_starters.web\_agent module
+----------------------------------------------------------
+
+.. automodule:: steamship.experimental.package_starters.web_agent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.experimental.package\_starters.web\_bot module
+--------------------------------------------------------
+
+.. automodule:: steamship.experimental.package_starters.web_bot
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.experimental.rst
+++ b/docs/api/steamship.experimental.rst
@@ -1,0 +1,20 @@
+steamship.experimental package
+==============================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   steamship.experimental.easy
+   steamship.experimental.package_starters
+   steamship.experimental.transports
+
+Module contents
+---------------
+
+.. automodule:: steamship.experimental
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.experimental.transports.rst
+++ b/docs/api/steamship.experimental.transports.rst
@@ -1,0 +1,37 @@
+steamship.experimental.transports package
+=========================================
+
+Submodules
+----------
+
+steamship.experimental.transports.steamship\_widget module
+----------------------------------------------------------
+
+.. automodule:: steamship.experimental.transports.steamship_widget
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.experimental.transports.telegram module
+-------------------------------------------------
+
+.. automodule:: steamship.experimental.transports.telegram
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.experimental.transports.transport module
+--------------------------------------------------
+
+.. automodule:: steamship.experimental.transports.transport
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.experimental.transports
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.invocable.rst
+++ b/docs/api/steamship.invocable.rst
@@ -12,6 +12,14 @@ steamship.invocable.config module
    :undoc-members:
    :show-inheritance:
 
+steamship.invocable.dev\_logging\_handler module
+------------------------------------------------
+
+.. automodule:: steamship.invocable.dev_logging_handler
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 steamship.invocable.entrypoint module
 -------------------------------------
 
@@ -24,6 +32,14 @@ steamship.invocable.invocable module
 ------------------------------------
 
 .. automodule:: steamship.invocable.invocable
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.invocable.invocable\_localhost module
+-----------------------------------------------
+
+.. automodule:: steamship.invocable.invocable_localhost
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/api/steamship.plugin.outputs.rst
+++ b/docs/api/steamship.plugin.outputs.rst
@@ -28,6 +28,14 @@ steamship.plugin.outputs.model\_checkpoint module
    :undoc-members:
    :show-inheritance:
 
+steamship.plugin.outputs.plugin\_output module
+----------------------------------------------
+
+.. automodule:: steamship.plugin.outputs.plugin_output
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 steamship.plugin.outputs.raw\_block\_and\_tag\_plugin\_output module
 --------------------------------------------------------------------
 

--- a/docs/api/steamship.rst
+++ b/docs/api/steamship.rst
@@ -7,10 +7,12 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
+   steamship.agents
    steamship.base
    steamship.cli
    steamship.client
    steamship.data
+   steamship.experimental
    steamship.invocable
    steamship.plugin
    steamship.utils

--- a/docs/api/steamship.utils.rst
+++ b/docs/api/steamship.utils.rst
@@ -12,6 +12,14 @@ steamship.utils.binary\_utils module
    :undoc-members:
    :show-inheritance:
 
+steamship.utils.context\_length module
+--------------------------------------
+
+.. automodule:: steamship.utils.context_length
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 steamship.utils.huggingface\_helper module
 ------------------------------------------
 
@@ -32,6 +40,14 @@ steamship.utils.metadata module
 -------------------------------
 
 .. automodule:: steamship.utils.metadata
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.utils.repl module
+---------------------------
+
+.. automodule:: steamship.utils.repl
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Each `Steamship package <https://www.steamship.com/packages>`_ runs in the cloud
 
 Steamship in 30 seconds
 -----------------------
+- :ref:`Build Agents<Building Agents>` which run in the cloud.
 - :ref:`Use Plugins<Using Plugins>` for common operations like generating text with GPT, converting a CSV to text, or generating an image from text. Steamship manages asynchronicity and retries.
 - :ref:`Store data in Files, Blocks, and Tags <Data Model>`. This allows you to :ref:`query <Queries>` or :ref:`search <Embedding Search Index>` it later.
 - :ref:`Deploy as a Package<Developing Packages>`, creating a scalable API for your front end.
@@ -89,6 +90,7 @@ Contents
    :maxdepth: 4
 
    Configuration <configuration/index>
+   Agents <agents/index>
    Packages <packages/index>
    Plugins <plugins/index>
    Data <data/index>


### PR DESCRIPTION
This is very basic, but just wanted to have some links from the front page that could navigate you to some info about Agents and to the Guidebook.

(you can ignore everything in the PR except docs/agents/index.rst and docs/index.rst)