### PR TITLE
feat: Make easier for Invocable instance to register a route

### DIFF
--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -215,7 +215,7 @@ class Invocable(ABC):
     ) -> MethodSpec:
         """Register a mapping that permits a method to be invoked via HTTP."""
         method_spec = MethodSpec.from_class(
-            cls, name, path=path, verb=verb, config=config, func_name_binding=name
+            cls, name, path=path, verb=verb, config=config, func_binding=name
         )
         cls._package_spec.add_method(method_spec)
         return method_spec

--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -220,24 +220,6 @@ class Invocable(ABC):
         cls._package_spec.add_method(method_spec)
         return method_spec
 
-    # def _register_instance_mapping(
-    #     self,
-    #     name: str,
-    #     verb: Optional[Verb] = None,
-    #     path: str = "",
-    #     config: Dict[str, Union[int, float, bool, str]] = None,
-    # ) -> MethodSpec:
-    #     """Register a mapping that permits a method to be invoked via HTTP.
-    #
-    #     This is the instance-level version of the registry.
-    #     """
-    #     method_spec = MethodSpec.from_class(cls, name, path=path, verb=verb, config=config)
-    #     # It's important to use method_spec.path below since that's the CLEANED path.
-    #     cls._method_mappings[verb][method_spec.path] = name
-    #     logging.info(f"[{cls.__name__}] {verb} {path} => {name}")
-    #     return method_spec
-    # ):
-
     def _get_method_spec(self, verb: Verb, path: str) -> Optional[MethodSpec]:
         """Return the MethodSpec matching an HTTP route and path."""
         logging.info(f"REQUEST [{verb}] {path}")

--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -4,8 +4,6 @@ import logging
 import pathlib
 import time
 from abc import ABC
-from collections import defaultdict
-from copy import deepcopy
 from functools import wraps
 from http import HTTPStatus
 from typing import Any, Dict, Optional, Type, Union
@@ -96,7 +94,6 @@ class Invocable(ABC):
       3. Provides useful methods connecting functions to the router.
     """
 
-    _method_mappings = defaultdict(dict)
     _package_spec: PackageSpec
     config: Config
     context: InvocationContext
@@ -153,12 +150,6 @@ class Invocable(ABC):
         # The subclass always overrides whatever the superclass set here, having cloned its data.
         cls._package_spec = _package_spec
 
-        if cls._method_mappings:
-            # Make a deep copy so that subclasses don't accidentally modify superclass & sibling instances
-            cls._method_mappings = deepcopy(cls._method_mappings)
-        else:
-            cls._method_mappings = defaultdict(dict)
-
         base_fn_list = [
             may_be_decorated
             for base_cls in cls.__bases__
@@ -171,22 +162,16 @@ class Invocable(ABC):
                     path = getattr(attribute, "__path__", None)
                     verb = getattr(attribute, "__verb__", None)
                     config = getattr(attribute, "__endpoint_config__", {})
-                    method_spec = cls._register_mapping(
+                    cls._register_mapping(
                         name=attribute.__name__, verb=verb, path=path, config=config
                     )
-                    cls._package_spec.add_method(method_spec)
 
         # Add the HTTP GET /__dir__ method which returns a serialization of the PackageSpec.
-        # Wired up to both GET and POST for convenience (since POST is the default from the Python client, but
-        # GET is the default if using from a browser).
+        # Wired up to both GET and POST for convenience (POST is Steamship default; GET is browser friendly)
         cls._register_mapping(name="__steamship_dir__", verb=Verb.GET, path="/__dir__")
         cls._register_mapping(name="__steamship_dir__", verb=Verb.POST, path="/__dir__")
-
-        # Connect the __instance_init__ route to the wrapper method; append it to the method list so it's visible to the engine
-        cls._package_spec.add_method(
-            cls._register_mapping(
-                name="invocable_instance_init", verb=Verb.POST, path="/__instance_init__", config={}
-            )
+        cls._register_mapping(
+            name="invocable_instance_init", verb=Verb.POST, path="/__instance_init__", config={}
         )
         end_time = time.time()
         logging.info(f"Registered package functions in {end_time - start_time} seconds.")
@@ -228,52 +213,71 @@ class Invocable(ABC):
         path: str = "",
         config: Dict[str, Union[int, float, bool, str]] = None,
     ) -> MethodSpec:
-        """Registering a mapping permits the method to be invoked via HTTP."""
-        method_spec = MethodSpec.from_class(cls, name, path=path, verb=verb, config=config)
-        # It's important to use method_spec.path below since that's the CLEANED path.
-        cls._method_mappings[verb][method_spec.path] = name
-        logging.info(f"[{cls.__name__}] {verb} {path} => {name}")
+        """Register a mapping that permits a method to be invoked via HTTP."""
+        method_spec = MethodSpec.from_class(
+            cls, name, path=path, verb=verb, config=config, func_name_binding=name
+        )
+        cls._package_spec.add_method(method_spec)
         return method_spec
+
+    # def _register_instance_mapping(
+    #     self,
+    #     name: str,
+    #     verb: Optional[Verb] = None,
+    #     path: str = "",
+    #     config: Dict[str, Union[int, float, bool, str]] = None,
+    # ) -> MethodSpec:
+    #     """Register a mapping that permits a method to be invoked via HTTP.
+    #
+    #     This is the instance-level version of the registry.
+    #     """
+    #     method_spec = MethodSpec.from_class(cls, name, path=path, verb=verb, config=config)
+    #     # It's important to use method_spec.path below since that's the CLEANED path.
+    #     cls._method_mappings[verb][method_spec.path] = name
+    #     logging.info(f"[{cls.__name__}] {verb} {path} => {name}")
+    #     return method_spec
+    # ):
+
+    def _get_method_spec(self, verb: Verb, path: str) -> Optional[MethodSpec]:
+        """Return the MethodSpec matching an HTTP route and path."""
+        logging.info(f"REQUEST [{verb}] {path}")
+
+        method_mappings = self.__class__._method_mappings
+
+        if verb not in method_mappings:
+            logging.error(f"_get_method_spec_for: Verb '{verb}' not found in method_mappings.")
+            return None
+
+        if path not in method_mappings[verb]:
+            logging.error(
+                f"_get_method_spec_for: Path '{path}' not found in method_mappings[{verb}]."
+            )
+            return None
+
+        return method_mappings[verb][path]
 
     def __call__(self, request: InvocableRequest, context: Any = None) -> InvocableResponse:
         """Invokes a method call if it is registered."""
-        if not hasattr(self.__class__, "_method_mappings"):
-            logging.error("__call__: No mappings available on invocable.")
-            return InvocableResponse.error(
-                code=HTTPStatus.NOT_FOUND, message="No mappings available for invocable."
-            )
-
         if request.invocation is None:
             logging.error("__call__: No invocation on request.")
             return InvocableResponse.error(
                 code=HTTPStatus.NOT_FOUND, message="No invocation was found."
             )
 
-        verb = Verb(request.invocation.http_verb.strip().upper())
+        verb = request.invocation.http_verb
         path = request.invocation.invocation_path
+        logging.info(f"REQUEST [{verb}] {path}")
 
-        path = MethodSpec.clean_path(path)
-
-        logging.info(f"[{verb}] {path}")
-
-        method_mappings = self.__class__._method_mappings
-
-        if verb not in method_mappings:
-            logging.error(f"__call__: Verb '{verb}' not found in method_mappings.")
-            return InvocableResponse.error(
-                code=HTTPStatus.NOT_FOUND,
-                message=f"No methods for verb {verb} available.",
-            )
-
-        if path not in method_mappings[verb]:
-            logging.error(f"__call__: Path '{path}' not found in method_mappings[{verb}].")
+        method_spec = self._package_spec.get_method(verb, path)
+        if method_spec is None:
             return InvocableResponse.error(
                 code=HTTPStatus.NOT_FOUND,
                 message=f"No handler for {verb} {path} available.",
             )
 
-        method = method_mappings[verb][path]
-        if not (hasattr(self, method) and callable(getattr(self, method))):
+        bound_function = method_spec.get_bound_function(self)
+
+        if not bound_function:
             logging.error(
                 f"__call__: Method not found or not callable for '{path}' in method_mappings[{verb}]."
             )
@@ -284,9 +288,9 @@ class Invocable(ABC):
 
         arguments = request.invocation.arguments
         if arguments is None:
-            return getattr(self, method)()
+            return bound_function()
         else:
-            return getattr(self, method)(**arguments)
+            return bound_function(**arguments)
 
     @classmethod
     def get_config_parameters(cls) -> Dict[str, ConfigParameter]:

--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -220,24 +220,6 @@ class Invocable(ABC):
         cls._package_spec.add_method(method_spec)
         return method_spec
 
-    def _get_method_spec(self, verb: Verb, path: str) -> Optional[MethodSpec]:
-        """Return the MethodSpec matching an HTTP route and path."""
-        logging.info(f"REQUEST [{verb}] {path}")
-
-        method_mappings = self.__class__._method_mappings
-
-        if verb not in method_mappings:
-            logging.error(f"_get_method_spec_for: Verb '{verb}' not found in method_mappings.")
-            return None
-
-        if path not in method_mappings[verb]:
-            logging.error(
-                f"_get_method_spec_for: Path '{path}' not found in method_mappings[{verb}]."
-            )
-            return None
-
-        return method_mappings[verb][path]
-
     def __call__(self, request: InvocableRequest, context: Any = None) -> InvocableResponse:
         """Invokes a method call if it is registered."""
         if request.invocation is None:

--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -190,13 +190,15 @@ class Invocable(ABC):
         self.instance_init()
         return InvocableResponse(data=True)
 
-    def add_api_route(self, method_spec: MethodSpec):
+    def add_api_route(self, method_spec: MethodSpec, permit_overwrite_of_existing: bool = False):
         """Add an API route to this Invocable instance."""
         if self._package_spec is None:
             raise SteamshipError(
                 message=f"Unable to add API route {method_spec}. Reason: _package_spec on Invocable was None."
             )
-        self._package_spec.add_method(method_spec)
+        self._package_spec.add_method(
+            method_spec, permit_overwrite_of_existing=permit_overwrite_of_existing
+        )
 
     def instance_init(self):
         """The instance init method will be called ONCE by the engine when a new instance of a package or plugin has been created. By default, this does nothing."""
@@ -231,7 +233,7 @@ class Invocable(ABC):
         method_spec = MethodSpec.from_class(
             cls, name, path=path, verb=verb, config=config, func_binding=name
         )
-        cls._package_spec.add_method(method_spec)
+        cls._package_spec.add_method(method_spec, permit_overwrite_of_existing=True)
         return method_spec
 
     def __call__(self, request: InvocableRequest, context: Any = None) -> InvocableResponse:

--- a/tests/assets/demo_package_spec.json
+++ b/tests/assets/demo_package_spec.json
@@ -4,6 +4,22 @@
   "doc": null,
   "methods": [
     {
+      "args": [],
+      "config": null,
+      "doc": "Return this Invocable's PackageSpec for remote inspection -- e.g. documentation or OpenAPI generation.",
+      "path": "/__dir__",
+      "returns": "<class 'dict'>",
+      "verb": "GET"
+    },
+    {
+      "args": [],
+      "config": null,
+      "doc": "Return this Invocable's PackageSpec for remote inspection -- e.g. documentation or OpenAPI generation.",
+      "path": "/__dir__",
+      "returns": "<class 'dict'>",
+      "verb": "POST"
+    },
+    {
        "args": [],
        "config": { },
        "doc": null,

--- a/tests/assets/demo_package_spec.json
+++ b/tests/assets/demo_package_spec.json
@@ -1,83 +1,68 @@
 {
   "name": "TestPackage",
-  "sdkVersion": "unknown",
-  "doc": null,
   "methods": [
     {
+      "returns": "<class 'dict'>",
       "args": [],
       "config": null,
-      "doc": "Return this Invocable's PackageSpec for remote inspection -- e.g. documentation or OpenAPI generation.",
       "path": "/__dir__",
-      "returns": "<class 'dict'>",
-      "verb": "GET"
+      "verb": "GET",
+      "doc": "Return this Invocable's PackageSpec for remote inspection -- e.g. documentation or OpenAPI generation."
     },
     {
+      "returns": "<class 'dict'>",
       "args": [],
       "config": null,
-      "doc": "Return this Invocable's PackageSpec for remote inspection -- e.g. documentation or OpenAPI generation.",
       "path": "/__dir__",
-      "returns": "<class 'dict'>",
-      "verb": "POST"
+      "verb": "POST",
+      "doc": "Return this Invocable's PackageSpec for remote inspection -- e.g. documentation or OpenAPI generation."
     },
     {
-       "args": [],
-       "config": { },
-       "doc": null,
-       "path": "/__instance_init__",
-       "returns": "<class 'steamship.invocable.invocable_response.InvocableResponse'>",
-       "verb": "POST"
-    },
-    {
-      "path": "/resp_string",
-      "doc": null,
+      "returns": "<class 'steamship.invocable.invocable_response.InvocableResponse'>",
       "args": [],
       "config": {},
-      "returns": "<class 'l_22bcb053.InvocableResponse[str]'>",
-      "verb": "GET"
+      "path": "/__instance_init__",
+      "verb": "POST",
+      "doc": null
     },
     {
-      "path": "/resp_dict",
-      "doc": null,
+      "returns": "<class 'foo.InvocableResponse[dict]'>",
       "args": [],
+      "path": "/config",
       "config": {},
       "verb": "GET",
-      "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>"
+      "doc": "This is called get_config because there's already `.config` object on the class."
     },
     {
-      "path": "/resp_obj",
-      "doc": null,
-      "args": [],
+      "returns": "<class 'foo.InvocableResponse[Task]'>",
+      "args": [
+        {
+          "name": "name",
+          "kind": "<class 'str'>",
+          "values": null
+        }
+      ],
       "config": {},
-      "verb": "GET",
-      "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>"
+      "path": "/future_greet",
+      "verb": "POST",
+      "doc": null
     },
     {
-      "path": "/resp_binary",
-      "doc": null,
-      "verb": "GET",
-      "returns": "<class 'l_22bcb053.InvocableResponse[bytes]'>",
-      "args": [],
-      "config": {}
+      "returns": "<class 'foo.InvocableResponse[Task]'>",
+      "args": [
+        {
+          "values": null,
+          "kind": "<class 'str'>",
+          "name": "name"
+        }
+      ],
+      "path": "/future_greet_then_greet_again",
+      "config": {},
+      "verb": "POST",
+      "doc": null
     },
     {
-      "path": "/resp_bytes_io",
-      "doc": null,
-      "verb": "GET",
-      "returns": "<class 'l_22bcb053.InvocableResponse[bytes]'>",
-      "args": [],
-      "config": {}
-    },
-    {
-      "path": "/resp_image",
-      "doc": null,
-      "returns": "<class 'l_22bcb053.InvocableResponse[bytes]'>",
-      "verb": "GET",
-      "args": [],
-      "config": {}
-    },
-    {
-      "path": "/greet",
-      "doc": null,
+      "returns": "<class 'foo.InvocableResponse[str]'>",
       "args": [
         {
           "name": "name",
@@ -86,142 +71,183 @@
         }
       ],
       "config": {
-        "body": 98.6,
         "identifier": "foo",
+        "timeout": 10,
         "public": true,
-        "timeout": 10
+        "body": 98.6
+      },
+      "path": "/greet",
+      "verb": "GET",
+      "doc": null
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[str]'>",
+      "args": [
+        {
+          "values": null,
+          "kind": "<class 'str'>",
+          "name": "name"
+        }
+      ],
+      "config": {},
+      "path": "/greet",
+      "verb": "POST",
+      "doc": null
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[dict]'>",
+      "args": [],
+      "path": "/json_with_status",
+      "config": {},
+      "verb": "POST",
+      "doc": "Our base client tries to be smart with parsing things that look like SteamshipResponse objects, but there's\n        a problem with this when our packages response with a JSON string of the sort {\"status\": \"foo\"} -- the Client\n        will unhelpfully try to coerce that string value into a Task object and fail. This method helps us test that\n        we are handling it properly."
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[dict]'>",
+      "args": [
+        {
+          "values": null,
+          "kind": "<class 'str'>",
+          "name": "fact"
+        }
+      ],
+      "config": {},
+      "path": "/learn",
+      "verb": "POST",
+      "doc": "Learns a new fact."
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[str]'>",
+      "args": [
+        {
+          "name": "name",
+          "kind": "<class 'str'>",
+          "values": null
+        }
+      ],
+      "path": "/public_get_greet",
+      "config": {
+        "public": true
       },
       "verb": "GET",
-      "returns": "<class 'l_22bcb053.InvocableResponse[str]'>"
+      "doc": null
     },
     {
-      "path": "/greet",
-      "doc": null,
-      "returns": "<class 'l_22bcb053.InvocableResponse[str]'>",
+      "returns": "<class 'foo.InvocableResponse[str]'>",
       "args": [
         {
-          "kind": "<class 'str'>",
+          "values": null,
           "name": "name",
-          "values": null
+          "kind": "<class 'str'>"
         }
       ],
-      "config": {},
-      "verb": "POST"
-    },
-   {
-     "args": [{"kind": "<class 'str'>", "name": "name", "values": null}],
-         "config": {"public": true},
-         "doc": null,
-         "path": "/public_post_greet",
-         "returns": "<class 'foo.InvocableResponse[str]'>",
-         "verb": "POST"
-     },
-     {
-         "args": [{"kind": "<class 'str'>", "name": "name", "values": null}],
-         "config": {"public": true},
-         "doc": null,
-         "path": "/public_get_greet",
-         "returns": "<class 'foo.InvocableResponse[str]'>",
-         "verb": "GET"
-    },
-     {
-         "args": [{"kind": "<class 'str'>", "name": "name",
-          "values": null}],
-         "config": {},
-         "doc": null,
-         "path": "/future_greet",
-         "returns": "<class 'foo.InvocableResponse[Task]'>",
-         "verb": "POST"
-     },
-     {
-         "args": [{"kind": "<class 'str'>", "name": "name",
-          "values": null}],
-         "config": {},
-         "doc": null,
-         "path": "/future_greet_then_greet_again",
-         "returns": "<class 'foo.InvocableResponse[Task]'>",
-         "verb": "POST"
-     },
-    {
-      "path": "/workspace",
-      "doc": null,
-      "returns": "<class 'l_22bcb053.InvocableResponse[str]'>",
-      "args": [],
-      "config": {},
-      "verb": "GET"
-    },
-    {
-      "path": "/raise_steamship_error",
-      "doc": null,
+      "path": "/public_post_greet",
+      "config": {
+        "public": true
+      },
       "verb": "POST",
-      "args": [],
-      "config": {},
-      "returns": "<class 'l_22bcb053.InvocableResponse[str]'>"
+      "doc": null
     },
     {
-      "path": "/raise_python_error",
-      "doc": null,
-      "verb": "POST",
-      "returns": "<class 'l_22bcb053.InvocableResponse[str]'>",
-      "config": {},
-      "args": []
-    },
-    {
-      "path": "/user_info",
-      "doc": null,
-      "verb": "POST",
-      "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>",
-      "config": {},
-      "args": []
-    },
-    {
-      "path": "/json_with_status",
-      "doc": "Our base client tries to be smart with parsing things that look like SteamshipResponse objects, but there's\n        a problem with this when our packages response with a JSON string of the sort {\"status\": \"foo\"} -- the Client\n        will unhelpfully try to coerce that string value into a Task object and fail. This method helps us test that\n        we are handling it properly.",
-      "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>",
-      "verb": "POST",
-      "config": {},
-      "args": []
-    },
-    {
-      "path": "/config",
-      "doc": "This is called get_config because there's already `.config` object on the class.",
-      "config": {},
-      "args": [],
-      "verb": "GET",
-      "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>"
-    },
-    {
-      "path": "/learn",
-      "doc": "Learns a new fact.",
-      "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>",
-      "config": {},
+      "returns": "<class 'foo.InvocableResponse[dict]'>",
       "args": [
         {
-          "name": "fact",
-          "kind": "<class 'str'>",
-          "values": null
-        }
-      ],
-      "verb": "POST"
-    },
-    {
-      "path": "/query",
-      "doc": "Learns a new fact.",
-      "returns": "<class 'l_22bcb053.InvocableResponse[dict]'>",
-      "config": {},
-      "args": [
-        {
+          "values": null,
           "name": "query",
-          "kind": "<class 'str'>",
-          "values": null
+          "kind": "<class 'str'>"
         },
         {
-          "name": "k",
+          "values": null,
           "kind": "<class 'int'>",
-          "values": null
+          "name": "k"
         }
       ],
-      "verb": "POST"
+      "config": {},
+      "path": "/query",
+      "verb": "POST",
+      "doc": "Learns a new fact."
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[str]'>",
+      "args": [],
+      "config": {},
+      "path": "/raise_python_error",
+      "verb": "POST",
+      "doc": null
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[str]'>",
+      "args": [],
+      "path": "/raise_steamship_error",
+      "config": {},
+      "verb": "POST",
+      "doc": null
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[bytes]'>",
+      "args": [],
+      "config": {},
+      "path": "/resp_binary",
+      "verb": "GET",
+      "doc": null
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[bytes]'>",
+      "args": [],
+      "config": {},
+      "path": "/resp_bytes_io",
+      "verb": "GET",
+      "doc": null
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[dict]'>",
+      "args": [],
+      "path": "/resp_dict",
+      "config": {},
+      "verb": "GET",
+      "doc": null
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[bytes]'>",
+      "args": [],
+      "config": {},
+      "path": "/resp_image",
+      "verb": "GET",
+      "doc": null
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[dict]'>",
+      "args": [],
+      "path": "/resp_obj",
+      "config": {},
+      "verb": "GET",
+      "doc": null
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[str]'>",
+      "args": [],
+      "config": {},
+      "path": "/resp_string",
+      "verb": "GET",
+      "doc": null
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[dict]'>",
+      "args": [],
+      "path": "/user_info",
+      "config": {},
+      "verb": "POST",
+      "doc": null
+    },
+    {
+      "returns": "<class 'foo.InvocableResponse[str]'>",
+      "args": [],
+      "config": {},
+      "path": "/workspace",
+      "verb": "GET",
+      "doc": null
     }
-  ]
+  ],
+  "sdkVersion": "unknown",
+  "doc": null
 }

--- a/tests/steamship_tests/app/integration/test_instance_init.py
+++ b/tests/steamship_tests/app/integration/test_instance_init.py
@@ -24,13 +24,13 @@ def test_instance_init_is_called_on_package():
 def test_plugin_init_dir():
     plugin = TestGeneratorWithInit()
     dir = plugin.__steamship_dir__()
-    assert len(dir.get("methods", [])) == 2
+    assert len(dir.get("methods", [])) == 4
 
 
 def test_package_init_dir():
     package = PackageWithInstanceInit()
     dir = package.__steamship_dir__()
-    assert len(dir.get("methods", [])) == 2
+    assert len(dir.get("methods", [])) == 4
 
 
 def test_instance_init_is_called_on_plugin():

--- a/tests/steamship_tests/app/integration/test_package_error_visibility.py
+++ b/tests/steamship_tests/app/integration/test_package_error_visibility.py
@@ -1,7 +1,7 @@
 import pytest
 from assets.packages.demo_package import TestPackage
 
-ERROR_NO_METHOD = "No handler for POST /method_doesnt_exist available."
+ERROR_NO_METHOD = "No handler for POST method_doesnt_exist available."
 ERROR_STEAMSHIP_ERROR = "[ERROR - POST raise_steamship_error] raise_steamship_error"
 ERROR_PYTHON_ERROR = "[ERROR - POST raise_python_error] raise_python_error"
 

--- a/tests/steamship_tests/app/unit/test_demo_app_spec.py
+++ b/tests/steamship_tests/app/unit/test_demo_app_spec.py
@@ -14,7 +14,7 @@ def test_package_spec(invocable_handler: Callable[[str, str, Optional[dict]], di
 
     assert rd.get("doc") is None
     assert rd.get("methods") is not None
-    assert len(rd.get("methods")) == 21
+    assert len(rd.get("methods")) == 23
 
     saw_public = False
 
@@ -32,7 +32,7 @@ def test_package_spec(invocable_handler: Callable[[str, str, Optional[dict]], di
             assert method.get("config") is not None
             assert method.get("config").get("public") is True
         else:
-            assert method.get("config") == {}
+            assert (method.get("config") == {}) or (method.get("config") is None)
 
     assert saw_public
 
@@ -42,7 +42,7 @@ def test_package_spec_fancy_types(invocable_handler: Callable[[str, str, Optiona
     """Test that the handler returns the proper directory information"""
     rd = invocable_handler("GET", "/__dir__", {}).get("data")
 
-    assert len(rd.get("methods")) == 3
+    assert len(rd.get("methods")) == 5
     for method in rd.get("methods"):
         if method.get("path") == "/enum_route":
             values = method.get("args")[0].get("values")
@@ -67,7 +67,7 @@ def test_package_spec_missing_configuration(
 
     assert rd.get("doc") is None
     assert rd.get("methods") is not None
-    assert len(rd.get("methods")) == 5
+    assert len(rd.get("methods")) == 7
 
 
 @pytest.mark.parametrize("invocable_handler", [OptionalParams], indirect=True)
@@ -77,8 +77,16 @@ def test_package_spec_optional_params(
     """Test that the handler returns the proper directory information"""
     rd = invocable_handler("GET", "/__dir__", {}).get("data")
 
-    assert len(rd.get("methods")) == 2
-    method = rd.get("methods")[1]
+    assert len(rd.get("methods")) == 4
+    method = None
+    for a_method in rd.get("methods"):
+        if a_method.get("path") not in ["/__dir__", "/__instance_init__"]:
+            method = a_method
+            break
+
+    assert method is not None
+    assert len(method.get("args")) > 0
+
     values = method.get("args")[0].get("values")
     assert values is not None
     assert len(values) == 2

--- a/tests/steamship_tests/app/unit/test_routes_on_superclasses.py
+++ b/tests/steamship_tests/app/unit/test_routes_on_superclasses.py
@@ -71,9 +71,9 @@ def invoke(o: Invocable, path: str):
 def test_l1_routes():
     """Tests that we can inspect the L1 routes"""
     l1 = L1Invocable()
-    assert l1._method_mappings[Verb.POST]["/foo"] == "foo"
-    assert l1._method_mappings[Verb.POST]["/bar"] == "bar"
-    assert l1._method_mappings[Verb.POST]["/baz"] == "baz"
+    assert l1._package_spec.method_mappings[Verb.POST]["/foo"].func_name_binding == "foo"
+    assert l1._package_spec.method_mappings[Verb.POST]["/bar"].func_name_binding == "bar"
+    assert l1._package_spec.method_mappings[Verb.POST]["/baz"].func_name_binding == "baz"
     assert invoke(l1, "foo") == "l1_foo"
     assert invoke(l1, "bar") == "l1_bar"
     assert invoke(l1, "baz") == "l1_baz"
@@ -82,20 +82,21 @@ def test_l1_routes():
     assert "/foo" in routes
     assert "/bar" in routes
     assert "/baz" in routes
+    assert len(routes) == 6  # __instance__init + 2x __dir__
 
 
 def test_l2_routes():
     """Tests that we can inspect the L1 routes"""
     l2 = L2Invocable()
-    assert l2._method_mappings[Verb.POST]["/foo"] == "foo"
-    assert l2._method_mappings[Verb.POST]["/bar"] == "bar"
-    assert l2._method_mappings[Verb.POST]["/baz"] == "baz"
+    assert l2._package_spec.method_mappings[Verb.POST]["/foo"].func_name_binding == "foo"
+    assert l2._package_spec.method_mappings[Verb.POST]["/bar"].func_name_binding == "bar"
+    assert l2._package_spec.method_mappings[Verb.POST]["/baz"].func_name_binding == "baz"
     assert invoke(l2, "foo") == "l1_foo"
     assert invoke(l2, "bar") == "l2_bar"
     assert invoke(l2, "baz") == "l2_baz"
 
     routes = [m["path"] for m in l2.__steamship_dir__()["methods"]]
-    assert len(routes) == 4  # the fourth is __instance__init
+    assert len(routes) == 6  # __instance__init + 2x __dir__
     assert "/foo" in routes
     assert "/bar" in routes
     assert "/baz" in routes
@@ -104,15 +105,15 @@ def test_l2_routes():
 def test_l3_routes():
     """Tests that we can inspect the L1 routes"""
     l3 = L3Invocable()
-    assert l3._method_mappings[Verb.POST]["/foo"] == "foo"
-    assert l3._method_mappings[Verb.POST]["/bar"] == "bar"
-    assert l3._method_mappings[Verb.POST]["/baz"] == "baz"
+    assert l3._package_spec.method_mappings[Verb.POST]["/foo"].func_name_binding == "foo"
+    assert l3._package_spec.method_mappings[Verb.POST]["/bar"].func_name_binding == "bar"
+    assert l3._package_spec.method_mappings[Verb.POST]["/baz"].func_name_binding == "baz"
     assert invoke(l3, "foo") == "l1_foo"
     assert invoke(l3, "bar") == "l2_bar"
     assert invoke(l3, "baz") == "l3_baz"
 
     routes = [m["path"] for m in l3.__steamship_dir__()["methods"]]
-    assert len(routes) == 4  # the fourth is __instance__init
+    assert len(routes) == 6  # __instance__init + 2x __dir__
     assert "/foo" in routes
     assert "/bar" in routes
     assert "/baz" in routes
@@ -121,15 +122,15 @@ def test_l3_routes():
 def test_l22_routes():
     """Tests that we can inspect the L1 routes"""
     l22 = L2Invocable2()
-    assert l22._method_mappings[Verb.POST]["/foo"] == "foo"
-    assert l22._method_mappings[Verb.POST]["/bar"] == "bar2"
-    assert l22._method_mappings[Verb.POST]["/baz"] == "baz2"
+    assert l22._package_spec.method_mappings[Verb.POST]["/foo"].func_name_binding == "foo"
+    assert l22._package_spec.method_mappings[Verb.POST]["/bar"].func_name_binding == "bar2"
+    assert l22._package_spec.method_mappings[Verb.POST]["/baz"].func_name_binding == "baz2"
     assert invoke(l22, "foo") == "l1_foo"
     assert invoke(l22, "bar") == "l22_bar"
     assert invoke(l22, "baz") == "l22_baz"
 
     routes = [m["path"] for m in l22.__steamship_dir__()["methods"]]
-    assert len(routes) == 4  # the fourth is __instance__init
+    assert len(routes) == 6  # __instance__init + 2x __dir__
     assert "/foo" in routes
     assert "/bar" in routes
     assert "/baz" in routes
@@ -140,14 +141,14 @@ def test_l32_routes():
     l32 = L3Invocable2()
 
     routes = [m["path"] for m in l32.__steamship_dir__()["methods"]]
-    assert len(routes) == 4  # the fourth is __instance__init
+    assert len(routes) == 6  # __instance__init + 2x __dir__
     assert "/foo" in routes
     assert "/bar" in routes
     assert "/baz" in routes
 
-    assert l32._method_mappings[Verb.POST]["/foo"] == "foo"
-    assert l32._method_mappings[Verb.POST]["/bar"] == "bar2"
-    assert l32._method_mappings[Verb.POST]["/baz"] == "baz3"
+    assert l32._package_spec.method_mappings[Verb.POST]["/foo"].func_name_binding == "foo"
+    assert l32._package_spec.method_mappings[Verb.POST]["/bar"].func_name_binding == "bar2"
+    assert l32._package_spec.method_mappings[Verb.POST]["/baz"].func_name_binding == "baz3"
     assert invoke(l32, "foo") == "l1_foo"
     assert invoke(l32, "bar") == "l22_bar"
     assert invoke(l32, "baz") == "l32_baz"
@@ -160,7 +161,7 @@ def test_telegram_agent(client: Steamship):
         config={"botToken": "foo"},
         incoming_message_agent=ReACTAgent(tools=[], llm=OpenAI(client=client)),
     )
-    assert a._method_mappings[Verb.POST]["/answer"] == "answer"
+    assert a._package_spec.method_mappings[Verb.POST]["/answer"].func_name_binding == "answer"
     routes = [m["path"] for m in a.__steamship_dir__()["methods"]]
     assert "/answer" in routes
     assert "/respond" in routes

--- a/tests/steamship_tests/app/unit/test_routes_on_superclasses.py
+++ b/tests/steamship_tests/app/unit/test_routes_on_superclasses.py
@@ -71,9 +71,9 @@ def invoke(o: Invocable, path: str):
 def test_l1_routes():
     """Tests that we can inspect the L1 routes"""
     l1 = L1Invocable()
-    assert l1._package_spec.method_mappings[Verb.POST]["/foo"].func_name_binding == "foo"
-    assert l1._package_spec.method_mappings[Verb.POST]["/bar"].func_name_binding == "bar"
-    assert l1._package_spec.method_mappings[Verb.POST]["/baz"].func_name_binding == "baz"
+    assert l1._package_spec.method_mappings[Verb.POST]["/foo"].func_binding == "foo"
+    assert l1._package_spec.method_mappings[Verb.POST]["/bar"].func_binding == "bar"
+    assert l1._package_spec.method_mappings[Verb.POST]["/baz"].func_binding == "baz"
     assert invoke(l1, "foo") == "l1_foo"
     assert invoke(l1, "bar") == "l1_bar"
     assert invoke(l1, "baz") == "l1_baz"
@@ -88,9 +88,9 @@ def test_l1_routes():
 def test_l2_routes():
     """Tests that we can inspect the L1 routes"""
     l2 = L2Invocable()
-    assert l2._package_spec.method_mappings[Verb.POST]["/foo"].func_name_binding == "foo"
-    assert l2._package_spec.method_mappings[Verb.POST]["/bar"].func_name_binding == "bar"
-    assert l2._package_spec.method_mappings[Verb.POST]["/baz"].func_name_binding == "baz"
+    assert l2._package_spec.method_mappings[Verb.POST]["/foo"].func_binding == "foo"
+    assert l2._package_spec.method_mappings[Verb.POST]["/bar"].func_binding == "bar"
+    assert l2._package_spec.method_mappings[Verb.POST]["/baz"].func_binding == "baz"
     assert invoke(l2, "foo") == "l1_foo"
     assert invoke(l2, "bar") == "l2_bar"
     assert invoke(l2, "baz") == "l2_baz"
@@ -105,9 +105,9 @@ def test_l2_routes():
 def test_l3_routes():
     """Tests that we can inspect the L1 routes"""
     l3 = L3Invocable()
-    assert l3._package_spec.method_mappings[Verb.POST]["/foo"].func_name_binding == "foo"
-    assert l3._package_spec.method_mappings[Verb.POST]["/bar"].func_name_binding == "bar"
-    assert l3._package_spec.method_mappings[Verb.POST]["/baz"].func_name_binding == "baz"
+    assert l3._package_spec.method_mappings[Verb.POST]["/foo"].func_binding == "foo"
+    assert l3._package_spec.method_mappings[Verb.POST]["/bar"].func_binding == "bar"
+    assert l3._package_spec.method_mappings[Verb.POST]["/baz"].func_binding == "baz"
     assert invoke(l3, "foo") == "l1_foo"
     assert invoke(l3, "bar") == "l2_bar"
     assert invoke(l3, "baz") == "l3_baz"
@@ -122,9 +122,9 @@ def test_l3_routes():
 def test_l22_routes():
     """Tests that we can inspect the L1 routes"""
     l22 = L2Invocable2()
-    assert l22._package_spec.method_mappings[Verb.POST]["/foo"].func_name_binding == "foo"
-    assert l22._package_spec.method_mappings[Verb.POST]["/bar"].func_name_binding == "bar2"
-    assert l22._package_spec.method_mappings[Verb.POST]["/baz"].func_name_binding == "baz2"
+    assert l22._package_spec.method_mappings[Verb.POST]["/foo"].func_binding == "foo"
+    assert l22._package_spec.method_mappings[Verb.POST]["/bar"].func_binding == "bar2"
+    assert l22._package_spec.method_mappings[Verb.POST]["/baz"].func_binding == "baz2"
     assert invoke(l22, "foo") == "l1_foo"
     assert invoke(l22, "bar") == "l22_bar"
     assert invoke(l22, "baz") == "l22_baz"
@@ -146,9 +146,9 @@ def test_l32_routes():
     assert "/bar" in routes
     assert "/baz" in routes
 
-    assert l32._package_spec.method_mappings[Verb.POST]["/foo"].func_name_binding == "foo"
-    assert l32._package_spec.method_mappings[Verb.POST]["/bar"].func_name_binding == "bar2"
-    assert l32._package_spec.method_mappings[Verb.POST]["/baz"].func_name_binding == "baz3"
+    assert l32._package_spec.method_mappings[Verb.POST]["/foo"].func_binding == "foo"
+    assert l32._package_spec.method_mappings[Verb.POST]["/bar"].func_binding == "bar2"
+    assert l32._package_spec.method_mappings[Verb.POST]["/baz"].func_binding == "baz3"
     assert invoke(l32, "foo") == "l1_foo"
     assert invoke(l32, "bar") == "l22_bar"
     assert invoke(l32, "baz") == "l32_baz"
@@ -161,7 +161,7 @@ def test_telegram_agent(client: Steamship):
         config={"botToken": "foo"},
         incoming_message_agent=ReACTAgent(tools=[], llm=OpenAI(client=client)),
     )
-    assert a._package_spec.method_mappings[Verb.POST]["/answer"].func_name_binding == "answer"
+    assert a._package_spec.method_mappings[Verb.POST]["/answer"].func_binding == "answer"
     routes = [m["path"] for m in a.__steamship_dir__()["methods"]]
     assert "/answer" in routes
     assert "/respond" in routes


### PR DESCRIPTION
This PR contains a slight refactoring of `Invocable`'s route registration code to make it easier for an `Invocable` instance to (1) register routes on itself, and (2) register routes against arbitrary function pointers.

## Current Situation

At present, route registration is done at the class-level, inside `__init_subclass__`, by associating HTTP routes with the **names** of functions to be called (rather than a pointers to that function).

This creates a number of frictions:

- It's very challenging for an Invocable instance (rather than classdef) to register a route
- It's very challenging for a helper library to contribute routes that should be mixed-in to an Invocable 

For example, the following things are near-impossible with our class-only registration system:

- Dynamically adding a new transport to (e.g. Slack, Telegram, Discord) to an Invocable
- Dynamically registering a callback into some Tool
- Dynamically registering a set of internal routes that aid in some async featuresset, like Ask My Book

## This refactor

This refactor implements a slight refactor to make it easier to register routes at the instance level. It does not change the manner of current execution.

1) It consolidates route registration into a set of helper methods (before this code was spread across various function bodies)
2) It consolidates more code into the PackageSpec and MethodSpec classes (following the design pattern of FastAPI)

As a result, the `__init__` method of an Invocable could now, from the instance perspective:

- Initialize a transport that registers the `/slack_webhook` route
- Initialize a tool that registers some specific callback
- Initialize a helper suite, such as the "Ask My.." mix-in, could register a set of HTTP paths that are used to sequence the import, chunking, and embedding of new documents
