### PR TITLE
Allow setting of public_data from block and file

### DIFF
--- a/docs/data/blocks.rst
+++ b/docs/data/blocks.rst
@@ -19,6 +19,7 @@ The following divisions of this file into blocks are all perfectly fine:
 Metadata and annotations about the content of the ``Block`` added via :ref:`Tags` on the ``Block`` .
 
 .. _Creating Blocks:
+
 Creating Blocks
 ---------------
 
@@ -28,3 +29,13 @@ to an existing file.
 Please see ``Block.create()`` and ``File.append_block()``.
 
 Read the :py:class:`Block PyDoc spec here<steamship.data.block.Block>`.
+
+.. _Public Blocks:
+
+Making Block Data Public
+------------------------
+
+If you want the raw data bytes of a ``Block`` to be publicly accessible, you can set the parameter ``public_data = True`` when calling ``Block.create()``.
+This is useful if you wish to share a generated image or audio file, or must make the content viewable in a place that cannot
+retain your Steamship API key.  You can also change the value of the ``public_data`` flag on an existing ``Block`` by calling
+``Block.set_public_data``.

--- a/docs/data/files.rst
+++ b/docs/data/files.rst
@@ -42,3 +42,12 @@ The quickest way to create data is to create Files with ``Block`` content direct
       blocks=[Block(text="Some example text")]
    )
 
+.. _Public Files:
+
+Making File Data Public
+------------------------
+
+If you want the raw data bytes of a ``File`` to be publicly accessible, you can set the parameter ``public_data = True`` when calling ``File.create()``.
+This is useful if you wish to share a generated image or audio file, or must make the content viewable in a place that cannot
+retain your Steamship API key.  You can also change the value of the ``public_data`` flag on an existing ``File`` by calling
+``File.set_public_data``.

--- a/docs/plugins/using/generators/index.rst
+++ b/docs/plugins/using/generators/index.rst
@@ -60,6 +60,9 @@ There are several ways to specify input to a ``Generator``:
    # Pass all the Blocks in the File
    generator_task = generator.generate(block_query='kind "some-relevant-tag-kind"')
 
+
+**Public output** If you wish to make the output of the generation public (for example an image or audio file), you can pass ``make_output_public = True`` to the call to ``generate``.
+
 Output
 ------
 

--- a/src/steamship/data/block.py
+++ b/src/steamship/data/block.py
@@ -187,6 +187,16 @@ class Block(CamelModel):
                 raw_response=True,
             )
 
+    def set_public_data(self, public_data: bool):
+        """Set the public_data flag on this Block. If this object already exists server-side, update the flag."""
+        self.public_data = public_data
+        if self.client is not None and self.id is not None:
+            req = {
+                "id": self.id,
+                "publicData": self.public_data,
+            }
+            return self.client.post("block/update", payload=req, expect=Block)
+
     def is_text(self) -> bool:
         """Return whether this is a text Block."""
         return self.mime_type == MimeTypes.TXT or (self.mime_type is None and self.text)

--- a/src/steamship/data/file.py
+++ b/src/steamship/data/file.py
@@ -257,6 +257,7 @@ class File(CamelModel):
         append_output_to_file: bool = True,
         options: Optional[dict] = None,
         wait_on_tasks: List[Task] = None,
+        make_output_public: bool = False,
     ) -> Task[GenerateResponse]:
         """Generate new content from this file. Assumes this file as context for input and output.  May specify start and end blocks."""
         from steamship.data.operations.generator import GenerateRequest, GenerateResponse
@@ -275,6 +276,7 @@ class File(CamelModel):
             append_output_to_file=append_output_to_file,
             output_file_id=output_file_id,
             options=options,
+            make_output_public=make_output_public,
         )
         return self.client.post(
             "plugin/instance/generate", req, expect=GenerateResponse, wait_on_tasks=wait_on_tasks
@@ -314,6 +316,7 @@ class File(CamelModel):
         content: Union[str, bytes] = None,
         url: Optional[str] = None,
         mime_type: Optional[MimeTypes] = None,
+        public_data: bool = False,
     ) -> Block:
         """Append a new block to this File.  This is a convenience wrapper around
         Block.create(). You should provide only one of text, content, or url.
@@ -329,6 +332,7 @@ class File(CamelModel):
             content=content,
             url=url,
             mime_type=mime_type,
+            public_data=public_data,
         )
         self.blocks.append(block)
         return block

--- a/src/steamship/data/file.py
+++ b/src/steamship/data/file.py
@@ -333,6 +333,16 @@ class File(CamelModel):
         self.blocks.append(block)
         return block
 
+    def set_public_data(self, public_data: bool):
+        """Set the public_data flag on this File. If this object already exists server-side, update the flag."""
+        self.public_data = public_data
+        if self.client is not None and self.id is not None:
+            req = {
+                "id": self.id,
+                "publicData": self.public_data,
+            }
+            return self.client.post("file/update", payload=req, expect=File)
+
 
 class FileQueryResponse(Response):
     files: List[File]

--- a/tests/steamship_tests/data/test_block.py
+++ b/tests/steamship_tests/data/test_block.py
@@ -213,3 +213,29 @@ def test_append_block_private_data(client: Steamship):
 
     assert response.text == "This is a test"
     assert response.headers["content-type"] == MimeTypes.TXT
+
+
+@pytest.mark.usefixtures("client")
+def test_set_public_data(client: Steamship):
+    file = File.create(client, blocks=[])
+    block = Block.create(client, file_id=file.id, content=bytes("This is a test", "utf-8"))
+
+    assert not block.public_data
+
+    # With public data false, call should fail
+    # Intentionally no API key
+    failed_response = requests.get(block.raw_data_url)
+    assert not failed_response.ok
+
+    # With public data true, call should succeed
+    block.set_public_data(True)
+    # Intentionally no API key
+    response = requests.get(block.raw_data_url)
+    assert response.text == "This is a test"
+    assert response.headers["content-type"] == MimeTypes.TXT
+
+    # Setting back to false, should fail again
+    block.set_public_data(False)
+    # Intentionally no API key
+    failed_response = requests.get(block.raw_data_url)
+    assert not failed_response.ok

--- a/tests/steamship_tests/data/test_file.py
+++ b/tests/steamship_tests/data/test_file.py
@@ -366,7 +366,7 @@ def test_file_public_data(client: Steamship):
 
 
 @pytest.mark.usefixtures("client")
-def test_append_block_private_data(client: Steamship):
+def test_file_private_data(client: Steamship):
     file = File.create(client, content=bytes("This is a test", "utf-8"))
     assert not file.public_data
 
@@ -382,3 +382,28 @@ def test_append_block_private_data(client: Steamship):
 
     assert response.text == "This is a test"
     assert response.headers["content-type"] == MimeTypes.TXT
+
+
+@pytest.mark.usefixtures("client")
+def test_set_public_data(client: Steamship):
+    file = File.create(client, content=bytes("This is a test", "utf-8"))
+
+    assert not file.public_data
+
+    # With public data false, call should fail
+    # Intentionally no API key
+    failed_response = requests.get(file.raw_data_url)
+    assert not failed_response.ok
+
+    # With public data true, call should succeed
+    file.set_public_data(True)
+    # Intentionally no API key
+    response = requests.get(file.raw_data_url)
+    assert response.text == "This is a test"
+    assert response.headers["content-type"] == MimeTypes.TXT
+
+    # Setting back to false, should fail again
+    file.set_public_data(False)
+    # Intentionally no API key
+    failed_response = requests.get(file.raw_data_url)
+    assert not failed_response.ok


### PR DESCRIPTION
The previous public_data PR did not include a method for altering the `public_data` status of a `Block` or `File`.  

This PR introduces `set_public_data` on both.