### PR TITLE
feat(agents): add temperature control to OpenAI LLM

### DIFF
--- a/src/steamship/agents/llms/openai.py
+++ b/src/steamship/agents/llms/openai.py
@@ -16,7 +16,9 @@ class OpenAI(LLM):
     generator: PluginInstance
     client: Steamship
 
-    def __init__(self, client, model_name: str = "gpt-3.5-turbo", *args, **kwargs):
+    def __init__(
+        self, client, model_name: str = "gpt-3.5-turbo", temperature: float = 0.4, *args, **kwargs
+    ):
         """Create a new instance.
 
         Valid model names are:
@@ -24,7 +26,9 @@ class OpenAI(LLM):
          - gpt-3.5-turbo
         """
         client = client
-        generator = client.use_plugin(PLUGIN_HANDLE, config={"model": model_name})
+        generator = client.use_plugin(
+            PLUGIN_HANDLE, config={"model": model_name, "temperature": temperature}
+        )
         super().__init__(client=client, generator=generator, *args, **kwargs)
 
     def complete(self, prompt: str, stop: Optional[str] = None) -> List[Block]:

--- a/src/steamship/agents/tools/text_generation/summarize_text_with_prompt_tool.py
+++ b/src/steamship/agents/tools/text_generation/summarize_text_with_prompt_tool.py
@@ -1,4 +1,7 @@
+from steamship import Steamship
+from steamship.agents.llms import OpenAI
 from steamship.agents.tools.text_generation.text_rewrite_tool import TextRewritingTool
+from steamship.agents.utils import with_llm
 from steamship.utils.repl import ToolREPL
 
 DEFAULT_PROMPT = """Instructions:
@@ -29,4 +32,7 @@ class SummarizeTextWithPromptTool(TextRewritingTool):
 
 
 if __name__ == "__main__":
-    ToolREPL(SummarizeTextWithPromptTool()).run()
+    with Steamship.temporary_workspace() as client:
+        ToolREPL(SummarizeTextWithPromptTool()).run_with_client(
+            client=client, context=with_llm(llm=OpenAI(client=client, temperature=0.9))
+        )


### PR DESCRIPTION
This provides a way to control the "creativity" of the OpenAI LLM in Agents. Combined with the AgentContext LLM storage, this allows builders to use a "less creative" LLM for Action selection and a "more creative" LLM for user interactions.