### PR TITLE
Emit Bug Fix [Disconcerting - explanation required]

### DIFF
--- a/src/steamship/agents/service/agent_service.py
+++ b/src/steamship/agents/service/agent_service.py
@@ -77,4 +77,5 @@ class AgentService(PackageService):
             f"Completed agent run. Result: {len(action.output or [])} blocks. {output_text_length} total text length. Emitting on {len(context.emit_funcs)} functions."
         )
         for func in context.emit_funcs:
+            logging.info(f"Emitting via function: {func.__name__}")
             func(action.output, context.metadata)

--- a/src/steamship/agents/service/agent_service.py
+++ b/src/steamship/agents/service/agent_service.py
@@ -70,5 +70,11 @@ class AgentService(PackageService):
             )
 
         context.completed_steps.append(action)
+        output_text_length = 0
+        if action.output is not None:
+            output_text_length = sum([len(block.text or "") for block in action.output])
+        logging.info(
+            f"Completed agent run. Result: {len(action.output or [])} blocks. {output_text_length} total text length. Emitting on {len(context.emit_funcs)} functions."
+        )
         for func in context.emit_funcs:
             func(action.output, context.metadata)

--- a/src/steamship/experimental/package_starters/telegram_agent.py
+++ b/src/steamship/experimental/package_starters/telegram_agent.py
@@ -60,8 +60,7 @@ class TelegramAgentService(SteamshipWidgetAgentService, ABC):
             if incoming_message is not None:
                 context = AgentContext.get_or_create(self.client, context_keys={"chat_id": chat_id})
                 context.chat_history.append_user_message(text=incoming_message.text)
-                if len(context.emit_funcs) == 0:
-                    context.emit_funcs.append(self.build_emit_func(chat_id=chat_id))
+                context.emit_funcs = [self.build_emit_func(chat_id=chat_id)]
 
                 response = self.run_agent(self.incoming_message_agent, context)
                 if response is not None:

--- a/src/steamship/experimental/package_starters/telegram_agent.py
+++ b/src/steamship/experimental/package_starters/telegram_agent.py
@@ -60,6 +60,7 @@ class TelegramAgentService(SteamshipWidgetAgentService, ABC):
             if incoming_message is not None:
                 context = AgentContext.get_or_create(self.client, context_keys={"chat_id": chat_id})
                 context.chat_history.append_user_message(text=incoming_message.text)
+                logging.info(f"Existing emit functions: {len(context.emit_funcs)}")
                 context.emit_funcs = [self.build_emit_func(chat_id=chat_id)]
 
                 response = self.run_agent(self.incoming_message_agent, context)

--- a/src/steamship/experimental/package_starters/web_agent.py
+++ b/src/steamship/experimental/package_starters/web_agent.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABC
 from typing import List, Optional
 
@@ -50,4 +51,5 @@ class SteamshipWidgetAgentService(AgentService, ABC):
         return self.message_output
 
     def save_for_emit(self, blocks: List[Block], metadata: Metadata):
+        logging.info(f"Emitting by saving to self of type {type(self)}")
         self.message_output = blocks

--- a/src/steamship/experimental/package_starters/web_agent.py
+++ b/src/steamship/experimental/package_starters/web_agent.py
@@ -40,6 +40,7 @@ class SteamshipWidgetAgentService(AgentService, ABC):
             self.client, context_keys={"chat_id": incoming_message.chat_id}
         )
         context.chat_history.append_user_message(text=incoming_message.text)
+        logging.info(f"Existing emit functions: {len(context.emit_funcs)}")
         context.emit_funcs = [self.save_for_emit]
         try:
             self.run_agent(self.incoming_message_agent, context)

--- a/src/steamship/experimental/package_starters/web_agent.py
+++ b/src/steamship/experimental/package_starters/web_agent.py
@@ -40,8 +40,7 @@ class SteamshipWidgetAgentService(AgentService, ABC):
             self.client, context_keys={"chat_id": incoming_message.chat_id}
         )
         context.chat_history.append_user_message(text=incoming_message.text)
-        if len(context.emit_funcs) == 0:
-            context.emit_funcs.append(self.save_for_emit)
+        context.emit_funcs = [self.save_for_emit]
         try:
             self.run_agent(self.incoming_message_agent, context)
         except Exception as e:


### PR DESCRIPTION
This is a fix for a bug where the first message to a web bot works, but subsequent calls do not.

The issue appears to be that SOMEHOW, the emit_func from the previous run is still present in memory.  This does not make any sense to me, nor does the "existing emit functions" logging support that.

AND YET - The other logging, of which emit function is being used, supports the existing-functions theory.  Before the change to overwrite the list, if you sent a message to the Web client, then a message to Telegram, the telegram call would attempt to use the web client's emit.  Also, changing the code to always overwrite the emit function list fixes the issue.