### PR TITLE
Fix python insanity

### DIFF
--- a/src/steamship/agents/schema/context.py
+++ b/src/steamship/agents/schema/context.py
@@ -19,7 +19,7 @@ class AgentContext:
     def id(self) -> str:
         return self.chat_history.file.id
 
-    metadata: Metadata = {}
+    metadata: Metadata
     """Allows storage of arbitrary information that may be useful for agents and tools."""
 
     client: Steamship
@@ -30,14 +30,19 @@ class AgentContext:
     agent-driven answer sent in response to those queries/prompts. It does NOT record any chat
     history related to agent execution and action selection."""
 
-    completed_steps: List[Action] = []
+    completed_steps: List[Action]
     """Record of agent-selected Actions and their outputs. This provides an ordered look at the
     execution sequence for this context."""
 
     # todo: in the future, this could be a set of callbacks like onError, onComplete, ...
-    emit_funcs: List[EmitFunc] = []
+    emit_funcs: List[EmitFunc]
     """Called when an agent execution has completed. These provide a way for the AgentService
     to return the result of an agent execution to the package that requested the agent execution."""
+
+    def __init__(self):
+        self.metadata = {}
+        self.completed_steps = []
+        self.emit_funcs = []
 
     @staticmethod
     def get_or_create(
@@ -49,6 +54,4 @@ class AgentContext:
         context = AgentContext()
         context.chat_history = history
         context.client = client
-        context.completed_steps = []
-        context.emit_funcs = []
         return context

--- a/src/steamship/agents/utils.py
+++ b/src/steamship/agents/utils.py
@@ -11,7 +11,6 @@ def with_llm(llm: LLM, context: Optional[AgentContext] = None) -> AgentContext:
     if context is None:
         # TODO: should we have a default context somehow?
         context = AgentContext()
-        context.completed_steps = []
     context.metadata[_LLM_KEY] = llm
     return context
 


### PR DESCRIPTION
This explains the previously unexplainable #409 .

```
>>> class A:
...    a_list=[]
...    def __init__(self):
...       self.a_list.append("a")
...
>>> a = A()
>>> a.a_list
['a']
>>> b = A()
>>> b.a_list
['a', 'a']
The gist being that a_list is a static class var, at least until you would overwrite it with an instance-level version:
>>> a.a_list = ['b']
>>> a.a_list
['b']
>>> b.a_list
['a', 'a']
```