### PR TITLE
fix(cli): ensure 'logs'  command has a message when '--help' is invoked.

### DIFF
--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -309,6 +309,8 @@ def logs(
     request_path: Optional[str] = None,
     field_values: Optional[str] = None,
 ):
+    """Retrieve logs within a workspace."""
+
     initialize(suppress_message=True)
     client = None
     try:


### PR DESCRIPTION
Updated output.

```
Usage: ship [OPTIONS] COMMAND [ARGS]

Options:
  --help  Show this message and exit.

Commands:
  deploy  Deploy the package or plugin in this directory
  info    Displays information about the current Steamship user.
  it      Deploy the package or plugin in this directory
  login   Log in to Steamship, creating ~/.steamship.json
  logs    Retrieve logs within a workspace.
  serve   Serve the local invocable
  ships   Ship some ships
  use     Create an instance of your package/plugin for use.
 ```