### PR TITLE
fix(llm lookup): allow Tools to specify fallback LLMs in lookups

### DIFF
--- a/src/steamship/agents/tools/question_answering/vector_search_qa_tool.py
+++ b/src/steamship/agents/tools/question_answering/vector_search_qa_tool.py
@@ -53,7 +53,7 @@ class VectorSearchQATool(VectorSearchTool):
             **{"source_text": "\n".join(source_texts), "question": question}
         )
 
-        return get_llm(context).complete(prompt=final_prompt)
+        return get_llm(context, default=OpenAI(client=context.client)).complete(prompt=final_prompt)
 
     def run(self, tool_input: List[Block], context: AgentContext) -> Union[List[Block], Task[Any]]:
         """Answers questions with the assistance of an Embedding Index plugin.

--- a/src/steamship/agents/tools/text_generation/json_object_generator.py
+++ b/src/steamship/agents/tools/text_generation/json_object_generator.py
@@ -139,7 +139,7 @@ class JsonObjectGeneratorTool(Tool):
         )
 
         # Perform the generation
-        llm = get_llm(context)
+        llm = get_llm(context, default=OpenAI(client=context.client))
         res = llm.complete(prompt, stop="}")
 
         # Make sure we only generated one block; anything else violates the assumptions of this code.

--- a/src/steamship/agents/tools/text_generation/text_rewrite_tool.py
+++ b/src/steamship/agents/tools/text_generation/text_rewrite_tool.py
@@ -39,7 +39,7 @@ class TextRewritingTool(Tool):
         output: List[Blocks]
             A list of blocks whose content has been rewritten. Synchronously produced (for now).
         """
-        llm = get_llm(context)
+        llm = get_llm(context, default=OpenAI(client=context.client))
 
         blocks = []
         for block in tool_input:

--- a/src/steamship/agents/utils.py
+++ b/src/steamship/agents/utils.py
@@ -15,6 +15,6 @@ def with_llm(llm: LLM, context: Optional[AgentContext] = None) -> AgentContext:
     return context
 
 
-def get_llm(context: AgentContext) -> Optional[LLM]:
+def get_llm(context: AgentContext, default: Optional[LLM] = None) -> Optional[LLM]:
     """Retrieves the LLM from the provided AgentContext (if it exists)."""
-    return context.metadata.get(_LLM_KEY, None)
+    return context.metadata.get(_LLM_KEY, default)


### PR DESCRIPTION
This provides our initial Tools with a "safer" way of getting an LLM as needed to perform their tasks.

Stylistically, there is a larger conversation to be had about the "right" way of passing LLMs to Tools, but this at least prevents  problematic usage with the existing pattern.

Fixes #415 