### PR TITLE
Keep track of already registered mixins

### DIFF
--- a/src/steamship/base/package_spec.py
+++ b/src/steamship/base/package_spec.py
@@ -14,7 +14,6 @@ from steamship.utils.url import Verb
 
 
 class RouteConflictError(SteamshipError):
-
     existing_method_spec: "MethodSpec"
 
     def __init__(self, message: str, existing_method_spec: "MethodSpec"):
@@ -183,7 +182,8 @@ class MethodSpec(CamelModel):
     def get_bound_function(self, service_instance: Optional[Any]) -> Optional[Callable[..., Any]]:
         """Get the bound method described by this spec.
 
-        The `func_binding`, if a string, resolves to a function on the provided Invocable. Else is just a function."""
+        The `func_binding`, if a string, resolves to a function on the provided Invocable. Else is just a function.
+        """
 
         if not self.func_binding:
             logging.error(
@@ -237,6 +237,9 @@ class PackageSpec(CamelModel):
 
     # The SDK version this package is deployed with
     sdk_version: str = steamship.__version__
+
+    # Which mixins this package leverages
+    used_mixins: Optional[List[str]] = None
 
     # Quick O(1) lookup into VERB+NAME
     method_mappings: Dict[str, Dict[str, MethodSpec]] = Field(None, exclude=True, repr=False)

--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -178,6 +178,7 @@ class Invocable(ABC):
         _package_spec = PackageSpec(name=cls.__name__, doc=cls.__doc__, methods=[])
         if hasattr(cls, "_package_spec"):
             _package_spec.import_parent_methods(cls._package_spec)
+            _package_spec.used_mixins = cls._package_spec.used_mixins or []
 
         # The subclass always overrides whatever the superclass set here, having cloned its data.
         cls._package_spec = _package_spec

--- a/src/steamship/invocable/package_service.py
+++ b/src/steamship/invocable/package_service.py
@@ -39,17 +39,12 @@ class PackageService(Invocable):
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
 
-        # The subclass takes care to extend what the superclass may have set here by copying it.
-        _package_spec = PackageSpec(name=cls.__name__, doc=cls.__doc__, methods=[])
-        if hasattr(cls, "_package_spec"):
-            _package_spec.import_parent_methods(cls._package_spec)
-
-        # The subclass always overrides whatever the superclass set here, having cloned its data.
-        cls._package_spec = _package_spec
-
         # Now must add routes for mixins
         for used_mixin_class in cls.USED_MIXIN_CLASSES:
-            cls.scan_mixin(cls._package_spec, used_mixin_class)
+            mixin_qualified_name = used_mixin_class.__module__ + "." + used_mixin_class.__qualname__
+            if mixin_qualified_name not in cls._package_spec.used_mixins:
+                cls.scan_mixin(cls._package_spec, used_mixin_class)
+                cls._package_spec.used_mixins.append(mixin_qualified_name)
 
     @classmethod
     def scan_mixin(

--- a/tests/assets/demo_package_spec.json
+++ b/tests/assets/demo_package_spec.json
@@ -272,5 +272,6 @@
     }
   ],
   "sdkVersion": "unknown",
+  "usedMixins": [],
   "doc": null
 }

--- a/tests/steamship_tests/app/unit/test_mixins.py
+++ b/tests/steamship_tests/app/unit/test_mixins.py
@@ -70,3 +70,12 @@ def test_two_conflicting_mixins_raises_error():
         "When attempting to add mixin TestMixin2, route POST test_mixin_route conflicted with already added route POST test_mixin_route on class TestMixin'"
         in str(e)
     )
+
+
+def test_mixins_declared_in_superclass():
+    class PackageWithMixinSubclass(PackageWithMixin):
+        pass
+
+    package = PackageWithMixinSubclass()
+    assert invoke(package, "test_mixin_route", text="test") == "mixin yo"
+    assert len(PackageWithMixinSubclass._package_spec.used_mixins) == 1


### PR DESCRIPTION
This fixes the reported issue where superclasses can't register mixins for you.