### PR TITLE
When using ngrok, don't append the local port to `invocable_url`

### DIFF
--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -151,6 +151,7 @@ def serve(
     manifest = load_manifest()
     invocable_config, is_file = config_str_to_dict(config)
     set_unset_params(config, invocable_config, is_file, manifest)
+    add_port_to_invocable_url = True
 
     if ngrok or ui:
         try:
@@ -166,6 +167,7 @@ def serve(
         public_url = http_tunnel.public_url
         click.secho(f" 🌎 Public URL: {public_url}")
         base_url = public_url
+        add_port_to_invocable_url = False  # NGROK's URL will redirect to the local port already
 
     server = SteamshipHTTPServer(
         invocable_class,
@@ -176,6 +178,7 @@ def serve(
         invocable_instance_handle=invocable_instance_handle,
         default_api_key=api_key,
         config=invocable_config,
+        add_port_to_invocable_url=add_port_to_invocable_url,
     )
     if ui:
         web_base = DEFAULT_WEB_BASE

--- a/src/steamship/cli/local_server/handler.py
+++ b/src/steamship/cli/local_server/handler.py
@@ -92,9 +92,13 @@ def make_handler(  # noqa: C901
                 user_for_key[client.config.api_key] = user
 
             if add_port_to_invocable_url:
-                url = f"{base_url}:{port}/"
+                url = f"{base_url}:{port}"
             else:
-                url = f"{base_url}/"
+                url = f"{base_url}"
+
+            # Append a trailing slash if not already there.
+            if not url.endswith("/"):
+                url = url + "/"
 
             return InvocationContext(
                 user_id=user.id,

--- a/src/steamship/cli/local_server/handler.py
+++ b/src/steamship/cli/local_server/handler.py
@@ -38,6 +38,7 @@ def make_handler(  # noqa: C901
     invocable_version_handle: str = None,
     invocable_instance_handle: str = None,
     config: dict = None,
+    add_port_to_invocable_url: bool = True,  # The invocable url represents the external URL, which may be NGROK
 ):
     """Creates and returns a SimpleHTTPRequestHandler class for an Invocable (package or plugin).
 
@@ -90,7 +91,10 @@ def make_handler(  # noqa: C901
                 user = User.current(client)
                 user_for_key[client.config.api_key] = user
 
-            url = f"{base_url}:{port}/"
+            if add_port_to_invocable_url:
+                url = f"{base_url}:{port}/"
+            else:
+                url = f"{base_url}/"
 
             return InvocationContext(
                 user_id=user.id,

--- a/src/steamship/cli/local_server/server.py
+++ b/src/steamship/cli/local_server/server.py
@@ -27,6 +27,7 @@ class SteamshipHTTPServer:
     invocable_handle: str = (None,)
     invocable_version_handle: str = (None,)
     invocable_instance_handle: str = (None,)
+    add_port_to_invocable_url: bool = True
 
     def __init__(
         self,
@@ -38,6 +39,7 @@ class SteamshipHTTPServer:
         invocable_version_handle: str = None,
         invocable_instance_handle: str = None,
         config: dict = None,
+        add_port_to_invocable_url: bool = True,  # The invocable url represents the external URL, which may be NGROK
     ):
         self.invocable = invocable
         self.port = port
@@ -47,6 +49,7 @@ class SteamshipHTTPServer:
         self.invocable_version_handle = invocable_version_handle
         self.invocable_instance_handle = invocable_instance_handle
         self.config = config
+        self.add_port_to_invocable_url = add_port_to_invocable_url
 
     def start(self):
         """Start the server."""
@@ -61,6 +64,7 @@ class SteamshipHTTPServer:
                 invocable_version_handle=self.invocable_version_handle,
                 invocable_instance_handle=self.invocable_instance_handle,
                 config=self.config,
+                add_port_to_invocable_url=self.add_port_to_invocable_url,
             ),
         )
         self.server.serve_forever()


### PR DESCRIPTION
The `invocable_url` on the context represents the externally-visible URL of the instance.

When running on localhost, this should include the port that the local server is running on.

But when running with NGROK involved, the local port is within the ngrok pipe, and the ngrok url should be used without modification.

