### PR TITLE
Fix index pipeline mixin test again

### DIFF
--- a/src/steamship/invocable/mixins/file_importer_mixin.py
+++ b/src/steamship/invocable/mixins/file_importer_mixin.py
@@ -1,9 +1,9 @@
+import logging
 from typing import List, Optional, Tuple
 
 import requests
 
 from steamship import DocTag, File, MimeTypes, Steamship, SteamshipError, Tag, Task
-from steamship.agents import logging
 from steamship.invocable import post
 from steamship.invocable.package_mixin import PackageMixin
 from steamship.utils.file_tags import update_file_status

--- a/tests/steamship_tests/app/integration/test_e2e_mixins_indexer_pipeline.py
+++ b/tests/steamship_tests/app/integration/test_e2e_mixins_indexer_pipeline.py
@@ -12,7 +12,7 @@ def test_indexer_pipeline_mixin(client: Steamship):
 
     with deploy_package(client, demo_package_path) as (_, _, instance):
         # Test indexing a pdf file
-        pdf_url = "https://file-examples.com/storage/fe396452246495b989f22f7/2017/10/file-sample_150kB.pdf"
+        pdf_url = "https://www.orimi.com/pdf-test.pdf"
 
         index_task = instance.invoke("index_url", url=pdf_url)
         index_task = Task.parse_obj(index_task)
@@ -23,7 +23,7 @@ def test_indexer_pipeline_mixin(client: Steamship):
 
         index_task.wait()
 
-        result = instance.invoke("search_index", query="auctor condimentum", k=1)
+        result = instance.invoke("search_index", query="education", k=1)
         result = SearchResults.parse_obj(result)
         assert len(result.items) == 1
         winner = result.items[0]


### PR DESCRIPTION
The last PDF document I changed this test to stopped working.

I've altered the PDF again; if this one stops working I will upload one to somewhere under our control.

The previous test not working also highlighted a wrong-import problem with the logs in the mixin, which is fixed here.