### PR TITLE
fix(docs): reported issue with example packages

### DIFF
--- a/docs/api/steamship.agents.mixins.rst
+++ b/docs/api/steamship.agents.mixins.rst
@@ -1,0 +1,18 @@
+steamship.agents.mixins package
+===============================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   steamship.agents.mixins.transports
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.mixins
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.mixins.transports.rst
+++ b/docs/api/steamship.agents.mixins.transports.rst
@@ -1,0 +1,37 @@
+steamship.agents.mixins.transports package
+==========================================
+
+Submodules
+----------
+
+steamship.agents.mixins.transports.steamship\_widget module
+-----------------------------------------------------------
+
+.. automodule:: steamship.agents.mixins.transports.steamship_widget
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.mixins.transports.telegram module
+--------------------------------------------------
+
+.. automodule:: steamship.agents.mixins.transports.telegram
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.agents.mixins.transports.transport module
+---------------------------------------------------
+
+.. automodule:: steamship.agents.mixins.transports.transport
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.mixins.transports
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.agents.tools.video_generation.rst
+++ b/docs/api/steamship.agents.tools.video_generation.rst
@@ -1,0 +1,21 @@
+steamship.agents.tools.video\_generation package
+================================================
+
+Submodules
+----------
+
+steamship.agents.tools.video\_generation.did\_video\_generator\_tool module
+---------------------------------------------------------------------------
+
+.. automodule:: steamship.agents.tools.video_generation.did_video_generator_tool
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.agents.tools.video_generation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.invocable.mixins.rst
+++ b/docs/api/steamship.invocable.mixins.rst
@@ -1,0 +1,45 @@
+steamship.invocable.mixins package
+==================================
+
+Submodules
+----------
+
+steamship.invocable.mixins.blockifier\_mixin module
+---------------------------------------------------
+
+.. automodule:: steamship.invocable.mixins.blockifier_mixin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.invocable.mixins.file\_importer\_mixin module
+-------------------------------------------------------
+
+.. automodule:: steamship.invocable.mixins.file_importer_mixin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.invocable.mixins.indexer\_mixin module
+------------------------------------------------
+
+.. automodule:: steamship.invocable.mixins.indexer_mixin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+steamship.invocable.mixins.indexer\_pipeline\_mixin module
+----------------------------------------------------------
+
+.. automodule:: steamship.invocable.mixins.indexer_pipeline_mixin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: steamship.invocable.mixins
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/steamship.rst
+++ b/docs/api/steamship.rst
@@ -9,7 +9,6 @@ Subpackages
 
    steamship.agents
    steamship.base
-   steamship.bots
    steamship.cli
    steamship.client
    steamship.data

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,7 +125,13 @@ release = ""  # Is set by calling `setup.py docs`
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".venv"]
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    ".venv",
+    "packages/cookbook/article-tagging.rst",
+]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 # default_role = None

--- a/docs/packages/cookbook/adding-configuration.rst
+++ b/docs/packages/cookbook/adding-configuration.rst
@@ -70,8 +70,9 @@ Next, we tell the Steamship handler how to find our config class:
 
     class ConfigurableFavoritesPackage(PackageService):
         ...
-        def config_cls(self) -> Type[Config]:
-            return self.FavoritesConfig
+        @classmethod
+        def config_cls(cls) -> Type[Config]:
+            return cls.FavoritesConfig
 
 Now when implementing a method, we can use the config fields via ``self.config.<field_name>``!
 
@@ -100,7 +101,7 @@ When you put it all together, it looks like this:
     from typing import Dict, Any, Type
 
     from steamship import Steamship
-    from steamship.invocable import PackageService, Config, post, create_handler
+    from steamship.invocable import PackageService, Config, post
 
 
     class ConfigurableFavoritesPackage(PackageService):
@@ -112,7 +113,7 @@ When you put it all together, it looks like this:
             lucky_number: float
             favorite_true_false_value: bool
 
-        def __init__(self, client: Steamship, config: Dict[str, Any] = None):
+        def __init__(self, client: Steamship, config: Dict[str, Any] = None, context: InvocationContext = None):
             # The superclass init method turns the config param (a Dict)
             # into the self.config object (here, a FavoritesConfig)
             super().__init__(client, config)
@@ -123,9 +124,9 @@ When you put it all together, it looks like this:
         # See Developer Reference -> Accepting Configuration
         # for more details. This package uses a few configuration fields
         # to record the package user's favorite things.
-        def config_cls(self) -> Type[Config]:
-            """Return our config object"""
-            return self.FavoritesConfig
+        @classmethod
+        def config_cls(cls) -> Type[Config]:
+            return cls.FavoritesConfig
 
         # This method defines the package user's endpoint for adding content
         # The @post annotation automatically makes the method available as
@@ -143,8 +144,3 @@ When you put it all together, it looks like this:
             Your favorite true/false value is {self.config.favorite_true_false_value}.
             Wow, mine too!
             """
-
-
-    # This line connects our Package implementation class to the surrounding
-    # Steamship handler code.
-    handler = create_handler(ConfigurableFavoritesPackage)

--- a/tests/assets/packages/adding_configuration.py
+++ b/tests/assets/packages/adding_configuration.py
@@ -1,0 +1,50 @@
+"""
+THIS SHOULD BE KEPT IN SYNC WITH THE DOCS: packages/adding-configuration.rst.
+"""
+from typing import Any, Dict, Type
+
+from steamship import Steamship
+from steamship.invocable import Config, InvocationContext, PackageService, post
+
+
+class ConfigurableFavoritesPackage(PackageService):
+    class FavoritesConfig(Config):
+        """Configuration required to instantiate this package."""
+
+        name: str
+        favorite_color: str
+        lucky_number: float
+        favorite_true_false_value: bool
+
+    def __init__(
+        self, client: Steamship, config: Dict[str, Any] = None, context: InvocationContext = None
+    ):
+        # The superclass init method turns the config param (a Dict)
+        # into the self.config object (here, a FavoritesConfig)
+        super().__init__(client, config)
+
+    # The config_cls method allows your package to return a class
+    # that defines its required configuration.
+    # See Developer Reference -> Accepting Configuration
+    # for more details. This package uses a few configuration fields
+    # to record the package user's favorite things.
+    @classmethod
+    def config_cls(cls) -> Type[Config]:
+        return cls.FavoritesConfig
+
+    # This method defines the package user's endpoint for adding content
+    # The @post annotation automatically makes the method available as
+    # an HTTP Post request. The name in the annotation defines the HTTP
+    # route suffix, see Packages -> Package Project Structure.
+    @post("my_faves")
+    def my_faves(self) -> str:
+        """Return the user's favorites, in a string."""
+
+        return f"""
+        Hey {self.config.name}!
+        I can remind you of your favorites.
+        Your favorite color is {self.config.favorite_color}.
+        Your lucky number is {self.config.lucky_number}.
+        Your favorite true/false value is {self.config.favorite_true_false_value}.
+        Wow, mine too!
+        """

--- a/tests/assets/packages/article_tagging.py
+++ b/tests/assets/packages/article_tagging.py
@@ -1,0 +1,81 @@
+"""
+THIS SHOULD BE KEPT IN SYNC WITH THE DOCS: packages/article-tagging.rst.
+"""
+from typing import Any, Dict, Type
+
+from steamship import Block, File, Steamship, Tag
+from steamship.invocable import Config, InvocationContext, PackageService, post
+
+
+class ArticleTaggerPackage(PackageService):
+    class ArticleTaggerConfig(Config):
+        """Configuration required to instantiate this package."""
+
+        labels: str  # A comma-separated list of tags to apply to articles
+
+    def __init__(
+        self, client: Steamship, config: Dict[str, Any] = None, context: InvocationContext = None
+    ):
+        super().__init__(client, config)
+
+        # Instantiate a zero-shot classifier plugin
+        self.classifier_instance = client.use_plugin(
+            plugin_handle="zero-shot-tagger-default",
+            instance_handle="my-classifier",
+            config={
+                "tag_kind": "tags",  # The tag.kind we want in the output
+                "labels": self.config.labels,  # The labels we want to apply
+                "multi_label": True,  # multi-class classification
+            },
+        )
+
+    # The config_cls method allows your package to return a class
+    # that defines its required configuration.
+    # See Developer Reference -> Accepting Configuration
+    # for more details. This package doesn't have any specific
+    # required configuration, so we return the default Config object.
+    @classmethod
+    def config_cls(cls) -> Type[Config]:
+        """Return our specific config type."""
+        return cls.ArticleTaggerConfig
+
+    # This method defines the package user's endpoint for adding content
+    # The @post annotation automatically makes the method available as
+    # an HTTP Post request. The name in the annotation defines the HTTP
+    # route suffix, see Packages -> Package Project Structure.
+    @post("add_document")
+    def add_document(self, content: str, url: str) -> str:
+        """Accept a new document in plaintext and start sentiment analysis"""
+
+        # Upload the content of the file into Steamship.
+        # Put the content directly into a Block, since we assume it is plaintext.
+        # Create a tag with the URL so we can get it back later.
+        file = File.create(
+            self.client, blocks=[Block(text=content)], tags=[Tag(kind="url", name=url)]
+        )
+
+        # Tag the file with the sentiment analysis plugin
+        # Using a plugin is an asynchronous call within Steamship. The
+        # operation may not be complete when this method completes,
+        # but that's ok. The other methods will query over whatever is
+        # currently available.
+        file.tag(self.classifier_instance.handle)
+
+        return file.handle
+
+    @staticmethod
+    def _find_url(file: File):
+        for tag in file.tags:
+            if tag.kind == "url":
+                return tag.name
+
+    @post("documents_by_tag")
+    def documents_by_tag(self, tag: str, threshold: float = 0.7) -> [str]:
+        """Query the stored documents for tagged articles"""
+
+        # Query our documents for Positive sentiment tags
+        matching_files = File.query(
+            self.client, f'kind "tags" and name "{tag}" and value("score") > {threshold}'
+        ).files
+
+        return [self._find_url(file) for file in matching_files]

--- a/tests/steamship_tests/app/integration/test_adding_configuration.py
+++ b/tests/steamship_tests/app/integration/test_adding_configuration.py
@@ -1,0 +1,42 @@
+from steamship_tests import PACKAGES_PATH
+from steamship_tests.utils.deployables import deploy_package
+from steamship_tests.utils.fixtures import get_steamship_client
+
+
+def test_adding_configuration():
+    """NOTE: Any changes to the package under test need to be reflected in the paired documentation pages!"""
+
+    client = get_steamship_client()
+    demo_package_path = PACKAGES_PATH / "adding_configuration.py"
+    config_template = {
+        "name": {"type": "string"},
+        "favoriteColor": {"type": "string"},
+        "luckyNumber": {"type": "number"},
+        "favoriteTrueFalseValue": {"type": "boolean"},
+    }
+    instance_config = {
+        "name": "Shaggy",
+        "favoriteColor": "avocado green",
+        "luckyNumber": 42,
+        "favoriteTrueFalseValue": True,
+    }
+
+    with deploy_package(
+        client,
+        demo_package_path,
+        version_config_template=config_template,
+        instance_config=instance_config,
+    ) as (_, _, instance):
+        response = instance.invoke("my_faves")
+        assert response is not None
+        assert (
+            response
+            == """
+        Hey Shaggy!
+        I can remind you of your favorites.
+        Your favorite color is avocado green.
+        Your lucky number is 42.0.
+        Your favorite true/false value is True.
+        Wow, mine too!
+        """
+        )

--- a/tests/steamship_tests/app/integration/test_article_tagging.py
+++ b/tests/steamship_tests/app/integration/test_article_tagging.py
@@ -1,0 +1,56 @@
+import time
+
+import pytest
+from steamship_tests import PACKAGES_PATH
+from steamship_tests.utils.deployables import deploy_package
+from steamship_tests.utils.fixtures import get_steamship_client
+
+from steamship import File
+
+
+@pytest.mark.skip(
+    reason="article tagging depends on a classifier plugin that needs to be rewritten."
+)
+def test_article_tagging():
+    """NOTE: Any changes to the package under test need to be reflected in the paired documentation pages!"""
+
+    client = get_steamship_client()
+    demo_package_path = PACKAGES_PATH / "article_tagging.py"
+    config_template = {
+        "labels": {"type": "string"},
+    }
+    instance_config = {
+        "labels": "python,steamship",
+    }
+
+    with deploy_package(
+        client,
+        demo_package_path,
+        version_config_template=config_template,
+        instance_config=instance_config,
+    ) as (_, _, instance):
+        steamship_file_handle = instance.invoke(
+            "add_document", content="steamship, steamship, steamship.", url="https://steamship.com/"
+        )
+        instance.invoke(
+            "add_document",
+            content="python is to python as python is to python",
+            url="https://www.python.org/",
+        )
+
+        # because article tagging doesn't return tasks we can wait on, we retry for ~1m until we find a response.
+        tries = 10
+        delay = 6  # 6 seconds
+        while tries:
+            response = instance.invoke("documents_by_tag", tag="steamship")
+            if not response:
+                tries -= 1
+                if not tries:
+                    pytest.fail("documents were not tagged within time limit")
+                time.sleep(delay)
+            else:
+                assert len(response) == 1
+                assert response[0] == "https://steamship.com/"
+                steamship_file = File.get(client, handle=steamship_file_handle)
+                assert len(steamship_file.tags[0]) == 2
+                return


### PR DESCRIPTION
This updates the exposed docs as follows:
- Fixes the configuration example for two articles (per reported issue)
- Hides the article tagging cookbook recipe (pending restoration of function from plugin)
- Adds test for the two impacted docs
- Includes new generated SDK API docs from the `make html` bits.

Fixes #450 