### PR TITLE
do not submit: POC of agent context persist and async status update

### DIFF
--- a/src/steamship/agents/schema/context.py
+++ b/src/steamship/agents/schema/context.py
@@ -1,7 +1,11 @@
-from typing import Any, Callable, Dict, List
+import json
+from typing import Any, Callable, Dict, List, Optional
 
-from steamship import Block, Steamship, Tag
+from steamship import Block, File, Steamship, SteamshipError, Tag
 from steamship.agents.schema.action import Action
+from steamship.agents.schema.tool import Tool
+from steamship.data import TagKind
+from steamship.data.tags.tag_constants import ChatTag
 
 Metadata = Dict[str, Any]
 EmitFunc = Callable[[List[Block], Metadata], None]
@@ -54,6 +58,132 @@ class AgentContext:
 
         history = ChatHistory.get_or_create(client, context_keys, tags, searchable=searchable)
         context = AgentContext()
+        context.completed_steps = []
         context.chat_history = history
         context.client = client
         return context
+
+    def persist_to_file(self, client: Steamship, file_handle: Optional[str] = None):
+        handle = file_handle
+        if not handle:
+            handle = f"{self.id.lower()}-context"
+
+        try:
+            ctx_file = File.get(client=client, handle=handle)
+        except SteamshipError:
+            ctx_file = File.create(client=client, content="agent context file", handle=handle)
+
+        for block in ctx_file.blocks:
+            for tag in block.tags:
+                if tag.kind == "AgentContext":
+                    block.delete()
+
+        Block.create(
+            client=client,
+            file_id=ctx_file.id,
+            text=json.dumps(self.metadata),
+            tags=[Tag(kind="AgentContext", name="metadata")],
+        )
+
+        chat_history_tags = self.chat_history.tags
+        for tag in chat_history_tags:
+            if tag.kind == TagKind.CHAT and tag.name == ChatTag.CONTEXT_KEYS:
+                ctx_keys = tag.value
+
+        Block.create(
+            client=client,
+            file_id=ctx_file.id,
+            text=json.dumps(ctx_keys),
+            tags=[Tag(kind="AgentContext", name="context_keys")],
+        )
+
+        steps = self.completed_steps
+        # TODO(dougreid): this is lazy. really, we need both UUID and text for the text case.
+        json_steps = []
+        for step in steps:
+            json_inputs = []
+            for block in step.input:
+                if block.is_text():
+                    json_inputs.append({"text": block.text})
+                else:
+                    json_inputs.append({"uuid": block.id})
+
+            json_outputs = []
+            for block in step.output:
+                if block.is_text():
+                    json_outputs.append({"text": block.text})
+                else:
+                    json_outputs.append({"uuid": block.id})
+
+            json_step = {
+                "tool": step.tool.name,
+                "input": json_inputs,
+                "output": json_outputs,
+            }
+            json_steps.append(json_step)
+
+        Block.create(
+            client=client,
+            file_id=ctx_file.id,
+            text=json.dumps(json_steps),
+            tags=[Tag(kind="AgentContext", name="completed_steps")],
+        )
+
+        return handle
+
+    @staticmethod
+    def hydrate_from_file(client: Steamship, file_handle: str):
+        ctx_file = File.get(client=client, handle=file_handle)
+        if not ctx_file:
+            raise SteamshipError("context not found")
+
+        new_ctx = AgentContext()
+        new_ctx.completed_steps = []
+        new_ctx.client = client
+
+        for block in ctx_file.blocks:
+            for tag in block.tags:
+                if tag.kind == "AgentContext":
+                    if tag.name == "metadata":
+                        new_ctx.metadata = json.loads(block.text)
+                    elif tag.name == "context_keys":
+                        from steamship.agents.schema.chathistory import ChatHistory
+
+                        new_ctx.chat_history = ChatHistory.get_or_create(
+                            client=client, context_keys=json.loads(block.text)
+                        )
+                    elif tag.name == "completed_steps":
+                        json_steps = json.loads(block.text)
+                        for json_step in json_steps:
+                            input_blocks = []
+                            for json_input in json_step["input"]:
+                                for key, value in json_input.items():
+                                    if key == "text":
+                                        input_blocks.append(Block(text=value))
+                                    else:
+                                        input_blocks.append(Block.get(client=client, id=value))
+
+                            output_blocks = []
+                            for json_output in json_step["output"]:
+                                for key, value in json_output.items():
+                                    if key == "text":
+                                        output_blocks.append(Block(text=value))
+                                    else:
+                                        output_blocks.append(Block.get(client=client, id=value))
+
+                            action = Action(
+                                tool=PlaceholderTool(name=json_step["tool"]),
+                                input=input_blocks,
+                                output=output_blocks,
+                            )
+                            new_ctx.completed_steps.append(action)
+
+        return new_ctx
+
+
+class PlaceholderTool(Tool):
+    agent_description = "Placeholder"
+    human_description = "Placeholder"
+
+    def run(self, tool_input: List[Block], context: AgentContext):
+        return []

--- a/src/steamship/agents/service/agent_service.py
+++ b/src/steamship/agents/service/agent_service.py
@@ -41,6 +41,7 @@ class AgentService(PackageService):
             )
             action.output = blocks_or_task
             context.completed_steps.append(action)
+            context.persist_to_file(client=self.client)
 
     def run_agent(self, agent: Agent, context: AgentContext):
         action = agent.next_action(context=context)

--- a/tests/assets/packages/assistant_package.py
+++ b/tests/assets/packages/assistant_package.py
@@ -1,0 +1,141 @@
+import json
+import time
+import uuid
+from typing import List, Optional
+
+from steamship import Block
+from steamship.agents.llms.openai import OpenAI
+from steamship.agents.react import ReACTAgent
+from steamship.agents.schema import Action, AgentContext
+from steamship.agents.schema.context import Metadata
+from steamship.agents.schema.message_selectors import MessageWindowMessageSelector
+from steamship.agents.service.agent_service import AgentService
+from steamship.agents.tools.image_generation import DalleTool
+from steamship.agents.tools.search import SearchTool
+from steamship.invocable import post
+
+
+class MyAssistant(AgentService):
+    """MyAssistant is an example AgentService that exposes a single test endpoint
+    for trying out Agent-based invocations. It is configured with two simple Tools
+    to provide an overview of the types of tasks it can accomplish (here, search
+    and image generation)."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._agent = ReACTAgent(
+            tools=[
+                SearchTool(),
+                DalleTool(),
+            ],
+            llm=OpenAI(self.client, temperature=0, model="gpt-3.5-turbo"),
+            conversation_memory=MessageWindowMessageSelector(k=2),
+        )
+
+    @post("prompt")
+    def prompt(self, prompt: str, context_id: Optional[uuid.UUID] = None) -> str:
+        """Run an agent with the provided text as the input."""
+
+        # AgentContexts serve to allow the AgentService to run agents
+        # with appropriate information about the desired tasking.
+        # Here, we use the passed in context (or a new context) for the prompt,
+        # and append the prompt to the message history stored in the context.
+        if not context_id:
+            context_id = uuid.uuid4()
+        context = AgentContext.get_or_create(self.client, {"id": f"{context_id}"})
+        context.chat_history.append_user_message(prompt)
+
+        # AgentServices provide an emit function hook to access the output of running
+        # agents and tools. The emit functions fire at after the supplied agent emits
+        # a "FinishAction".
+        #
+        # Here, we show one way of accessing the output in a synchronous fashion. An
+        # alternative way would be to access the final Action in the `context.completed_steps`
+        # after the call to `run_agent()`.
+        output = ""
+
+        def sync_emit(blocks: List[Block], meta: Metadata):
+            nonlocal output
+            block_text = "\n".join(
+                [b.text if b.is_text() else f"({b.mime_type}: {b.id})" for b in blocks]
+            )
+            output += block_text
+
+        context.emit_funcs.append(sync_emit)
+        self.run_agent(self._agent, context)
+        # TODO: is this right?
+        context.chat_history.append_assistant_message(output)
+        return output
+
+    @post("/async_prompt")
+    def async_prompt(self, prompt: str) -> str:
+        context_id = uuid.uuid4()
+        context = AgentContext.get_or_create(self.client, {"id": f"{context_id}"})
+        context.chat_history.append_user_message(prompt)
+        file_handle = context.persist_to_file(client=self.client)
+
+        task = self.invoke_later(method="/_async_run", arguments={"file_handle": file_handle})
+        return json.dumps({"file_handle": file_handle, "task_id": task.task_id})
+
+    @post("/_async_run")
+    def async_run(self, file_handle: str):
+        context = AgentContext.hydrate_from_file(client=self.client, file_handle=file_handle)
+
+        for i in range(10):
+            context.completed_steps.append(
+                Action(
+                    tool=SearchTool(),
+                    input=[Block(text=f"{i}: blah blah")],
+                    output=[Block(text=f"{i}: done")],
+                )
+            )
+            context.persist_to_file(client=self.client)
+            time.sleep(2)
+
+        # TODO(dougreid): the ReAct agent is now sufficiently unreliable for this
+        # block of code to no longer work for demo / testing purposes. SIGH.
+        #
+        # output = ""
+        #
+        # def sync_emit(blocks: List[Block], meta: Metadata):
+        #     nonlocal output
+        #     block_text = "\n".join(
+        #         [b.text if b.is_text() else f"({b.mime_type}: {b.id})" for b in blocks]
+        #     )
+        #     output += block_text
+        #
+        # context.emit_funcs.append(sync_emit)
+        # try:
+        #     self.run_agent(self._agent, context)
+        #     context.chat_history.append_assistant_message(output)
+        #     context.persist_to_file(client=self.client, file_handle=file_handle)
+        # except:
+        #     output = "exception raised"
+        return "DONE"
+
+    @post("/completed_steps")
+    def completed_steps(self, file_handle: str):
+        ctx = AgentContext.hydrate_from_file(client=self.client, file_handle=file_handle)
+        steps = []
+        for step in ctx.completed_steps:
+            json_inputs = []
+            for block in step.input:
+                if block.is_text():
+                    json_inputs.append({"text": block.text})
+                else:
+                    json_inputs.append({"uuid": block.id})
+
+            json_outputs = []
+            for block in step.output:
+                if block.is_text():
+                    json_outputs.append({"text": block.text})
+                else:
+                    json_outputs.append({"uuid": block.id})
+
+            json_step = {
+                "tool": step.tool.name,
+                "input": json_inputs,
+                "output": json_outputs,
+            }
+            steps.append(json_step)
+        return json.dumps(steps)

--- a/tests/steamship_tests/agents/test_assistant.py
+++ b/tests/steamship_tests/agents/test_assistant.py
@@ -1,0 +1,36 @@
+import json
+
+import pytest
+from steamship_tests import PACKAGES_PATH
+from steamship_tests.utils.deployables import deploy_package
+
+from steamship import Steamship, Task, TaskState
+
+
+@pytest.mark.usefixtures("client")
+def test_async_run(client: Steamship):
+    demo_package_path = PACKAGES_PATH / "assistant_package.py"
+
+    with deploy_package(client, demo_package_path, wait_for_init=False) as (_, _, instance):
+        instance.wait_for_init()
+
+        out_json = instance.invoke(
+            "/async_prompt", prompt="draw me a picture of a cat in a silly hat"
+        )
+        out_dict = json.loads(out_json)
+
+        task = Task.get(client=client, _id=out_dict.get("task_id"))
+        while task.state not in [TaskState.succeeded, TaskState.failed]:
+            steps = instance.invoke("/completed_steps", file_handle=out_dict.get("file_handle"))
+            print("---")
+            print(steps)
+            try:
+                task.wait(max_timeout_s=5)
+                task.refresh()
+            except:
+                print("async waiting continues...")
+
+        print("finished!")
+        steps = instance.invoke("/completed_steps", file_handle=out_dict.get("file_handle"))
+        print("---")
+        print(steps)

--- a/tests/steamship_tests/agents/test_context.py
+++ b/tests/steamship_tests/agents/test_context.py
@@ -1,0 +1,26 @@
+import pytest
+
+from steamship import Block, Steamship
+from steamship.agents.schema import Action, AgentContext
+from steamship.agents.tools.search import SearchTool
+
+
+@pytest.mark.usefixtures("client")
+def test_context_persist_hydrate(client: Steamship):
+
+    ctx = AgentContext.get_or_create(client=client, context_keys={"id": "test-foo"})
+
+    ctx.chat_history.append_user_message("this is a test yo")
+    ctx.completed_steps.append(
+        Action(
+            tool=SearchTool(),
+            input=[Block(text="where's waldo?")],
+            output=[Block(text="location unknown")],
+        )
+    )
+
+    file_handle = ctx.persist_to_file(client=client)
+    retrieved_ctx = AgentContext.hydrate_from_file(client=client, file_handle=file_handle)
+
+    assert retrieved_ctx.chat_history.last_user_message.text == "this is a test yo"
+    assert len(retrieved_ctx.completed_steps) == 1


### PR DESCRIPTION
DO NOT SUBMIT

This PR is an attempt to sketch a possible path forward for "async" status reporting of agents, per discussion in meeting.

Main point of focus should be: [assistant_package.py](https://github.com/steamship-core/python-client/pull/459/files#diff-981ae5377c90472af81e1f10b111b270e544662498db1773783d41f738f7b1f1R71)

It is NOT meant to be an ideal path forward, but rather an exploration of the space that sparks discussions. It consists of a few key parts:
- making `AgentContext` serializable(-ish) and persisting it using `File` + `Block` tags.
- `invoke_later()` calls on the Agent service
- polling on a `/agent_context` endpoint.

A few small modifications could be made to such an approach:
- provide a more tailored `/agent_status` endpoint that only returns (completed) steps
- provide a `/known_contexts` endpoint that allows retrieval of in-flight contexts
- add `in-process steps` to `AgentContext` to provide even more insight
- more refined serialization.

DO NOT SUBMIT