### PR TITLE
bugfix: Parse output in FunctionsBasedOutputParser

### DIFF
--- a/src/steamship/agents/functional/output_parser.py
+++ b/src/steamship/agents/functional/output_parser.py
@@ -84,6 +84,7 @@ class FunctionsBasedOutputParser(OutputParser):
         if "function_call" in text:
             return self._extract_action_from_function_call(text, context)
 
-        finish_block = Block(text=text)
-        finish_block.set_chat_role(RoleTag.ASSISTANT)
-        return FinishAction(output=[finish_block], context=context)
+        finish_blocks = FunctionsBasedOutputParser._blocks_from_text(context.client, text)
+        for finish_block in finish_blocks:
+            finish_block.set_chat_role(RoleTag.ASSISTANT)
+        return FinishAction(output=finish_blocks, context=context)

--- a/tests/steamship_tests/agents/test_function_agent_output_parser.py
+++ b/tests/steamship_tests/agents/test_function_agent_output_parser.py
@@ -1,0 +1,20 @@
+import pytest
+
+from steamship import Block, File, Steamship
+from steamship.agents.functional import FunctionsBasedOutputParser
+from steamship.agents.schema import AgentContext, FinishAction
+
+
+@pytest.mark.usefixtures("client")
+def test_output_block_ids_are_converted(client: Steamship):
+    context = AgentContext()
+    context.client = client
+    block_id = File.create(client, blocks=[Block(text="test")]).blocks[0].id
+    test_text = f"Here is an image of an anteater: Block({block_id})."
+
+    output_formatter = FunctionsBasedOutputParser()
+    result = output_formatter.parse(test_text, context)
+
+    assert isinstance(result, FinishAction)
+    assert len(result.output) == 3
+    assert result.output[1].id == block_id


### PR DESCRIPTION
There was a missed call to `_blocks_from_text` when creating the FinishAction in `FunctionsBasedOutputParser`.   This resulted in returning text instead of Blocks for multimedia.