### PR TITLE
fix(cli): version bump logic and typo

### DIFF
--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -192,7 +192,10 @@ def serve(
 
         click.secho("")
         click.secho("To view the graphical UI, visit: ")
-        click.secho(f"    {web_base}/debug?endpoint={public_url}/answer")
+        if web_base.endswith("/"):
+            click.secho(f"    {web_base}debug?endpoint={public_url}/answer")
+        else:
+            click.secho(f"    {web_base}/debug?endpoint={public_url}/answer")
 
     def on_exit(signum, frame):
         click.secho("Shutting down server.")

--- a/src/steamship/cli/deploy.py
+++ b/src/steamship/cli/deploy.py
@@ -189,7 +189,7 @@ class DeployableDeployer(ABC):
 
         default_new = "1.0.0"
         try:
-            default_new = str(VersionInfo.parse(manifest.version).bump_prerelease())
+            default_new = str(VersionInfo.parse(manifest.version).next_version("prerelease"))
         except ValueError:
             pass
         old_archive_path = get_archive_path(manifest)


### PR DESCRIPTION
Small CLI changes to address version bumping (and typo in serve address).

From:
- `0.0.1` --> `0.0.2-rc.1` (instead of `0.0.1-rc.1`)
-  `https://steamship.com//debug?endpoint=...` to ` https://steamship.com/debug?endpoint=...`

Fixes SHIP-727