### PR TITLE
fix(agent): don't add blocks that contain only punctuation

### DIFF
--- a/src/steamship/agents/functional/output_parser.py
+++ b/src/steamship/agents/functional/output_parser.py
@@ -9,7 +9,10 @@ from steamship.data.tags.tag_constants import RoleTag
 
 
 def is_punctuation(text: str):
-    return text in string.punctuation
+    for c in text:
+        if c not in string.punctuation:
+            return False
+    return True
 
 
 class FunctionsBasedOutputParser(OutputParser):

--- a/src/steamship/utils/repl.py
+++ b/src/steamship/utils/repl.py
@@ -160,7 +160,7 @@ class AgentREPL(SteamshipREPL):
             from termcolor import colored  # noqa: F401
         except ImportError:
 
-            def colored(text: str, color: str):
+            def colored(text: str, color: str, **kwargs):
                 print(text)
 
         print("Starting REPL for Agent...")

--- a/tests/steamship_tests/agents/test_function_agent_output_parser.py
+++ b/tests/steamship_tests/agents/test_function_agent_output_parser.py
@@ -16,5 +16,5 @@ def test_output_block_ids_are_converted(client: Steamship):
     result = output_formatter.parse(test_text, context)
 
     assert isinstance(result, FinishAction)
-    assert len(result.output) == 3
+    assert len(result.output) == 2
     assert result.output[1].id == block_id


### PR DESCRIPTION
Trailing punctuation blocks are of little to no value (imho). This PR ensures that we don't add those blocks.

From:

```
Here is the image you requested: 
(image/png: B1A98152-A422-4B44-8FD9-D7C954E82D2A)
.
```

To:

```
Here is the image you requested: 
(image/png: B1A98152-A422-4B44-8FD9-D7C954E82D2A)
```