### PR TITLE
feat(agents): support persistent contexts in prompt and repl

### DIFF
--- a/src/steamship/agents/service/agent_service.py
+++ b/src/steamship/agents/service/agent_service.py
@@ -96,7 +96,7 @@ class AgentService(PackageService):
         # with appropriate information about the desired tasking.
         # Here, we create a new context on each prompt, and append the
         # prompt to the message history stored in the context.
-        context_id = uuid.uuid4()
+        context_id = kwargs.get("context_id") or uuid.uuid4()
         context = AgentContext.get_or_create(self.client, {"id": f"{context_id}"})
         context.chat_history.append_user_message(prompt)
 

--- a/src/steamship/utils/repl.py
+++ b/src/steamship/utils/repl.py
@@ -1,6 +1,7 @@
 import abc
 import contextlib
 import logging
+import uuid
 from abc import ABC
 from json import JSONDecodeError
 from typing import Any, Dict, List, Optional, Type, Union, cast
@@ -174,11 +175,20 @@ class AgentREPL(SteamshipREPL):
         self.agent_instance = self.agent_class(client=client, config=self.config)
 
         # Determine the responder, which may have been custom-supplied on the agent.
-        responder = getattr(self.agent_instance, self.method or "prompt")
+        method = self.method or "prompt"
+        if method == "prompt":
+            ctx = uuid.uuid4()
+        else:
+            ctx = None
+
+        responder = getattr(self.agent_instance, method)
 
         while True:
             input_text = input(colored(text="Input: ", color="blue"))  # noqa: F821
-            output = responder(input_text)
+            if ctx:
+                output = responder(input_text, context_id=ctx)
+            else:
+                output = responder(input_text)
             self.print_object_or_objects(output)
 
     def run(self, **kwargs):


### PR DESCRIPTION
Allow `prompt` to take a `context_id` argument that will allow frontends to maintain history/memory across calls. Then set up the REPL to exploit that when the method is `prompt`. This will allow for repl loops with memory.