### PR TITLE
feat(invoke): add invoke handlers for blocks and task

### DIFF
--- a/src/steamship/data/package/package_instance.py
+++ b/src/steamship/data/package/package_instance.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Type
 
 from pydantic import BaseModel, Field
 
-from steamship import SteamshipError
+from steamship import SteamshipError, Task
 from steamship.base.client import Client
 from steamship.base.model import CamelModel
 from steamship.base.request import DeleteRequest, IdentifierRequest, Request
@@ -123,6 +123,15 @@ class PackageInstance(CamelModel):
                 return [Block(client=self.client, **potential_blocks)]
         except Exception as e:
             raise SteamshipError(f"Could not convert to blocks: {e}")
+
+    def task_from_invoke(
+        self, path: str, verb: Verb = Verb.POST, timeout_s: Optional[float] = None, **kwargs
+    ) -> Task:
+        task_dict = self.invoke(path=path, verb=verb, timeout_s=timeout_s, **kwargs)
+        try:
+            return Task(client=self.client, **task_dict)
+        except Exception as e:
+            raise SteamshipError(f"Could not convert to task: {e}")
 
     def full_url_for(self, path: str):
         return f"{self.invocation_url}{path}"

--- a/src/steamship/data/package/package_instance.py
+++ b/src/steamship/data/package/package_instance.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, List, Optional, Type
 
 from pydantic import BaseModel, Field
 
@@ -9,6 +9,7 @@ from steamship import SteamshipError
 from steamship.base.client import Client
 from steamship.base.model import CamelModel
 from steamship.base.request import DeleteRequest, IdentifierRequest, Request
+from steamship.data.block import Block
 from steamship.data.invocable_init_status import InvocableInitStatus
 from steamship.data.workspace import Workspace
 from steamship.utils.url import Verb
@@ -110,6 +111,18 @@ class PackageInstance(CamelModel):
             as_background_task=False,
             timeout_s=timeout_s,
         )
+
+    def blocks_from_invoke(
+        self, path: str, verb: Verb = Verb.POST, timeout_s: Optional[float] = None, **kwargs
+    ) -> List[Block]:
+        potential_blocks = self.invoke(path=path, verb=verb, timeout_s=timeout_s, **kwargs)
+        try:
+            if isinstance(potential_blocks, list):
+                return [Block(client=self.client, **raw) for raw in potential_blocks]
+            else:
+                return [Block(client=self.client, **potential_blocks)]
+        except Exception as e:
+            raise SteamshipError(f"Could not convert to blocks: {e}")
 
     def full_url_for(self, path: str):
         return f"{self.invocation_url}{path}"

--- a/tests/assets/packages/returns_blocks.py
+++ b/tests/assets/packages/returns_blocks.py
@@ -1,0 +1,16 @@
+from steamship import Block, File
+from steamship.invocable import PackageService, post
+
+
+class ReturnsBlocks(PackageService):
+    @post("/blocks")
+    def blocks(self) -> [str]:
+        f = File.create(
+            self.client,
+            blocks=[
+                Block(text="test block 1"),
+                Block(text="test block 2"),
+                Block(text="test block 3"),
+            ],
+        )
+        return f.blocks


### PR DESCRIPTION
Hot take:  Getting raw dicts back from `invoke` is a usability concern. Since we are pushing `AgentService` with a builtin `prompt(): -> List[Block]`, we should have an easy way to actually get those blocks directly.

Proposed usage:

```python
answer_blocks = agent.blocks_from_invoke("prompt", prompt="What did I eat for dinner?", context_id="doug-dinner-discussion')

for block in answer_blocks:
   print(block.text)
```