### PR TITLE
fix(tests): add retries to model checkpoint test

### DIFF
--- a/src/steamship/plugin/outputs/model_checkpoint.py
+++ b/src/steamship/plugin/outputs/model_checkpoint.py
@@ -11,6 +11,18 @@ from steamship.utils.signed_urls import download_from_signed_url, upload_to_sign
 from steamship.utils.zip_archives import unzip_folder, zip_folder
 
 
+def _hash_file(path: Path):
+    import hashlib
+
+    md5 = hashlib.md5()  # noqa: S303 we don't need security, just a fingerprint
+    backing_bytes = bytearray(128 * 1024)
+    memory_view = memoryview(backing_bytes)
+    with open(path, "rb", buffering=0) as file:
+        while n := file.readinto(memory_view):
+            md5.update(memory_view[:n])
+    return md5.hexdigest()
+
+
 class ModelCheckpoint(CamelModel):
     # The default model checkpoint handle unless one is provided.
     DEFAULT_HANDLE: ClassVar[str] = "default"
@@ -79,7 +91,7 @@ class ModelCheckpoint(CamelModel):
         """
         return f"{self.plugin_instance_id}/{as_handle or self.handle}.zip"
 
-    def download_model_bundle(self) -> Path:
+    def download_model_bundle(self) -> (Path, str):
         """Download's the model from Steamship and unzips to `parent_directory`"""
         download_resp = self.workspace.create_signed_url(
             SignedUrl.Request(
@@ -94,13 +106,10 @@ class ModelCheckpoint(CamelModel):
             )
         download_from_signed_url(download_resp.signed_url, to_file=self.archive_path_on_disk())
         unzip_folder(self.archive_path_on_disk(), into_folder=self.folder_path_on_disk())
-        if not download_resp or not download_resp.signed_url:
-            raise SteamshipError(
-                message=f"Received empty Signed URL for model download of '{self.handle}."
-            )
-        download_from_signed_url(download_resp.signed_url, to_file=self.archive_path_on_disk())
-        unzip_folder(self.archive_path_on_disk(), into_folder=self.folder_path_on_disk())
-        return self.folder_path_on_disk()
+
+        version = _hash_file(self.archive_path_on_disk())
+
+        return self.folder_path_on_disk(), version
 
     def _upload_model_zip(self, as_handle: str = None):
         """Assumes a pre-zipped model, uploads to the requested zip.
@@ -126,10 +135,12 @@ class ModelCheckpoint(CamelModel):
 
         upload_to_signed_url(signed_url_resp.signed_url, filepath=self.archive_path_on_disk())
 
-    def upload_model_bundle(self, set_as_default: bool = True):
+    def upload_model_bundle(self, set_as_default: bool = True) -> str:
         """Zips and uploads the Model to steamship"""
         logging.info("ModelCheckpoint:upload_model_bundle")
-        zip_folder(self.folder_path_on_disk(), into_file=self.archive_path_on_disk())
+        file = zip_folder(self.folder_path_on_disk(), into_file=self.archive_path_on_disk())
+        version = _hash_file(file)
+
         self._upload_model_zip()
 
         if set_as_default:
@@ -138,3 +149,5 @@ class ModelCheckpoint(CamelModel):
             # - Once under the actual checkpoint name (e.g. `epoch-10`)
             # - Again under the name: default
             self._upload_model_zip(as_handle=ModelCheckpoint.DEFAULT_HANDLE)
+
+        return version

--- a/tests/steamship_tests/plugin/integration/test_e2e_trainable_tagger.py
+++ b/tests/steamship_tests/plugin/integration/test_e2e_trainable_tagger.py
@@ -81,7 +81,7 @@ def test_e2e_trainable_tagger_lambda_training(client: Steamship):
                     handle="default",
                     plugin_instance_id=tagger_instance.id,
                 )
-                checkpoint_path, _ = checkpoint.download_model_bundle()
+                checkpoint_path = checkpoint.download_model_bundle()
                 assert checkpoint_path.exists()
                 keyword_path = Path(checkpoint_path) / TestTrainableTaggerModel.KEYWORD_LIST_FILE
                 assert keyword_path.exists()
@@ -159,7 +159,7 @@ def test_e2e_trainable_tagger_lambda_training_new_train_params(client: Steamship
                     handle="default",
                     plugin_instance_id=tagger_instance.id,
                 )
-                checkpoint_path, _ = checkpoint.download_model_bundle()
+                checkpoint_path = checkpoint.download_model_bundle()
                 assert checkpoint_path.exists()
                 keyword_path = Path(checkpoint_path) / TestTrainableTaggerModel.KEYWORD_LIST_FILE
                 assert keyword_path.exists()

--- a/tests/steamship_tests/plugin/integration/test_e2e_trainable_tagger.py
+++ b/tests/steamship_tests/plugin/integration/test_e2e_trainable_tagger.py
@@ -81,7 +81,7 @@ def test_e2e_trainable_tagger_lambda_training(client: Steamship):
                     handle="default",
                     plugin_instance_id=tagger_instance.id,
                 )
-                checkpoint_path = checkpoint.download_model_bundle()
+                checkpoint_path, _ = checkpoint.download_model_bundle()
                 assert checkpoint_path.exists()
                 keyword_path = Path(checkpoint_path) / TestTrainableTaggerModel.KEYWORD_LIST_FILE
                 assert keyword_path.exists()
@@ -159,7 +159,7 @@ def test_e2e_trainable_tagger_lambda_training_new_train_params(client: Steamship
                     handle="default",
                     plugin_instance_id=tagger_instance.id,
                 )
-                checkpoint_path = checkpoint.download_model_bundle()
+                checkpoint_path, _ = checkpoint.download_model_bundle()
                 assert checkpoint_path.exists()
                 keyword_path = Path(checkpoint_path) / TestTrainableTaggerModel.KEYWORD_LIST_FILE
                 assert keyword_path.exists()


### PR DESCRIPTION
There is a test flake around DEFAULT checkpoints when multiple test runs happen at the same time. This PR is an attempt to solve that by attempting to rerun the checks until the hashes match.

I don't know if that's the best way to handle this issue, but it was all I could think of at the moment. Someone with a deeper understanding of the intended behavior here could possibly come up with a better solution.