### PR TITLE
bugfix: Tell isort to behave in a black-compliant way

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,7 @@ repos:
         require_serial: true
         language: python
         types: [python]
+        args: [ "--profile", "black" ]
       - id: black
         name: black
         entry: black


### PR DESCRIPTION
isort's default semantics conflict with black's default semantics. Sometimes this causes an endless loop of disagreement between them during the git precommit hooks.

This configuration line tells isort to behave in a black-compliant way.