### PR TITLE
feat: Use public block URLs for multimodal generations in Tools

### DIFF
--- a/src/steamship/agents/tools/base_tools.py
+++ b/src/steamship/agents/tools/base_tools.py
@@ -18,6 +18,7 @@ class GeneratorTool(Tool):
     generator_plugin_instance_handle: Optional[str] = None
     generator_plugin_config: dict = {}
     merge_blocks: bool = False
+    make_output_public: bool = False
 
     @abstractmethod
     def accept_output_block(self, block: Block) -> bool:
@@ -45,7 +46,9 @@ class GeneratorTool(Tool):
                 continue
 
             prompt = block.text
-            task = generator.generate(text=prompt, append_output_to_file=True)
+            task = generator.generate(
+                text=prompt, append_output_to_file=True, make_output_public=self.make_output_public
+            )
             tasks.append(task)
 
         # TODO / REMOVE Synchronous execution is a temporary simplification while we merge code.
@@ -78,6 +81,9 @@ class ImageGeneratorTool(GeneratorTool):
     A base class for tools that wrap Steamship Image Generator plugins.
     """
 
+    # So that generated image blocks can be accessed from chat clients
+    make_output_public: bool = True
+
     def accept_output_block(self, block: Block) -> bool:
         return block.is_image()
 
@@ -87,6 +93,9 @@ class VideoGeneratorTool(GeneratorTool):
     A base class for tools that wrap Steamship Video Generator plugins.
     """
 
+    # So that generated video blocks can be accessed from chat clients
+    make_output_public: bool = True
+
     def accept_output_block(self, block: Block) -> bool:
         return block.is_video()
 
@@ -95,6 +104,9 @@ class AudioGeneratorTool(GeneratorTool):
     """
     A base class for tools that wrap Steamship Audio Generator plugins.
     """
+
+    # So that generated audio blocks can be accessed from chat clients
+    make_output_public: bool = True
 
     def accept_output_block(self, block: Block) -> bool:
         return block.is_audio()

--- a/tests/steamship_tests/agents/tools/TestDalleTool.py
+++ b/tests/steamship_tests/agents/tools/TestDalleTool.py
@@ -1,0 +1,39 @@
+import pytest
+import requests
+
+from steamship import Block, Steamship
+from steamship.agents.llms import OpenAI
+from steamship.agents.schema import AgentContext
+from steamship.agents.tools.image_generation import DalleTool
+from steamship.agents.utils import with_llm
+
+
+@pytest.mark.usefixtures("client")
+def test_dalle_tool(client: Steamship):
+    """Tests that we can inspect the package and mixin routes"""
+    tool = DalleTool()
+    context = with_llm(
+        OpenAI(client=client),
+        AgentContext.get_or_create(client=client, context_keys={"id": "test"}),
+    )
+    res = tool.run([Block(text="Mario jumping over a fire flower")], context)
+    assert len(res) == 1
+    assert res[0].public_data is True
+
+    # Test that we can get the public data
+    block_url = f"{client.config.api_base}block/{res[0].id}/raw"
+    data = requests.get(block_url, json={"id": res[0].id})
+    assert data.ok is True
+    assert data.content is not None
+
+
+@pytest.mark.usefixtures("client")
+def test_dalle_tool_private_block(client: Steamship):
+    tool = DalleTool(make_output_public=False)
+    context = with_llm(
+        OpenAI(client=client),
+        AgentContext.get_or_create(client=client, context_keys={"id": "test"}),
+    )
+    res = tool.run([Block(text="Mario jumping over a fire flower")], context)
+    assert len(res) == 1
+    assert res[0].public_data is False


### PR DESCRIPTION
We added the public url feature so that chat clients would be able to easily render the output of multimodal blocks, but then we forgot to push the flag all the way up to the Agent Tools.

This PR adds:

- A default of a public block for image/audio/video blocks generated via tools
- Tests that the public URL works
- Tests that it can be set to private via an init arg

cc @maxwfreu who will likely use this in the Vercel integration