### PR TITLE
feat(agents): add caching for LLM calls and Actions

### DIFF
--- a/src/steamship/agents/examples/example_assistant_with_caching.py
+++ b/src/steamship/agents/examples/example_assistant_with_caching.py
@@ -1,0 +1,32 @@
+from steamship.agents.functional import FunctionsBasedAgent
+from steamship.agents.llms.openai import ChatOpenAI
+from steamship.agents.schema.message_selectors import MessageWindowMessageSelector
+from steamship.agents.service.agent_service import AgentService
+from steamship.agents.tools.image_generation import DalleTool
+from steamship.agents.tools.search import SearchTool
+from steamship.utils.repl import AgentREPL
+
+
+class MyCachingAssistant(AgentService):
+    """MyCachingAssistant is an example AgentService that exposes a single test endpoint
+    for trying out Agent-based invocations. It is configured with two simple Tools
+    to provide an overview of the types of tasks it can accomplish (here, search
+    and image generation)."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs, use_llm_cache=True, use_action_cache=True)
+        self._agent = FunctionsBasedAgent(
+            tools=[
+                SearchTool(),
+                DalleTool(),
+            ],
+            llm=ChatOpenAI(self.client, temperature=0),
+            conversation_memory=MessageWindowMessageSelector(k=2),
+        )
+
+
+if __name__ == "__main__":
+    # AgentREPL provides a mechanism for local execution of an AgentService method.
+    # This is used for simplified debugging as agents and tools are developed and
+    # added.
+    AgentREPL(MyCachingAssistant, agent_package_config={}).run()

--- a/src/steamship/agents/functional/output_parser.py
+++ b/src/steamship/agents/functional/output_parser.py
@@ -52,7 +52,7 @@ class FunctionsBasedOutputParser(OutputParser):
                     else:
                         input_blocks.append(Block(text=arguments, mime_type=MimeTypes.TXT))
 
-        return Action(tool=tool, input=input_blocks, context=context)
+        return Action(tool=tool.name, input=input_blocks, context=context)
 
     @staticmethod
     def _blocks_from_text(client: Steamship, text: str) -> List[Block]:

--- a/src/steamship/agents/logging.py
+++ b/src/steamship/agents/logging.py
@@ -30,6 +30,7 @@ class AgentLogging:
     OBSERVATION = "observation"
     ACTION = "action"
     MESSAGE = "message"
+    PROMPT = "prompt"
 
     MESSAGE_AUTHOR = "message_author"
     USER = "user"

--- a/src/steamship/agents/schema/action.py
+++ b/src/steamship/agents/schema/action.py
@@ -1,9 +1,8 @@
-from typing import Any, List, Optional, Union
+from typing import List, Optional
 
 from pydantic import BaseModel
 
-from steamship import Block, Tag, Task
-from steamship.agents.schema.tool import AgentContext, Tool
+from steamship import Block, Tag
 from steamship.data import TagKind
 from steamship.data.tags.tag_constants import RoleTag
 
@@ -14,19 +13,19 @@ class Action(BaseModel):
     Upon completion, the Action also contains the output of the Tool given the inputs.
     """
 
-    tool: Tool
-    """Tool used by this action."""
+    tool: str
+    """Name of tool used by this action."""
 
     input: List[Block]
     """Data provided directly to the Tool (full context is passed in run)."""
 
-    output: Optional[List[Block]] = []
+    output: Optional[List[Block]]
     """Any direct output produced by the Tool."""
 
     def to_chat_messages(self) -> List[Block]:
         tags = [
             Tag(kind=TagKind.ROLE, name=RoleTag.FUNCTION),
-            Tag(kind="name", name=self.tool.name),
+            Tag(kind="name", name=self.tool),
         ]
         blocks = []
         for block in self.output:
@@ -44,17 +43,8 @@ class Action(BaseModel):
         return blocks
 
 
-class AgentTool(Tool):
-    def run(self, tool_input: List[Block], context: AgentContext) -> Union[List[Block], Task[Any]]:
-        pass
-
-    name = "Agent"
-    human_description = "Placeholder tool object for FinishAction"
-    agent_description = ""  # intentionally left blank
-
-
 class FinishAction(Action):
     """Represents a final selected action in an Agent Execution."""
 
-    tool: Tool = AgentTool()  # Tool is hard-bound to allow storage in completed_steps in a context.
+    tool = "Agent-FinishAction"
     input: List[Block] = []

--- a/src/steamship/agents/schema/cache.py
+++ b/src/steamship/agents/schema/cache.py
@@ -1,0 +1,187 @@
+import hashlib
+import json
+import logging
+from typing import Dict, List, Optional
+
+from steamship import Block, MimeTypes, Steamship
+from steamship.agents.schema.action import Action, FinishAction
+from steamship.utils.kv_store import KeyValueStore
+
+
+def _blocks_to_cache_dict(value: List[Block]) -> Dict[str, any]:
+    """Attempts to convert a list of blocks to key-store-safe dictionary.
+
+    Convention: {'blocks':[{'id': <block_id>}, {'text': <some_text>}]}
+    """
+
+    if not value:
+        return {}
+    if not isinstance(value, list):
+        return {}
+    blocks = []
+    for block in value:
+        if block.id:
+            blocks.append({"id": block.id})
+        else:
+            # TODO(dougreid): safe assumption about temporary blocks?
+            blocks.append({"text": block.text})
+    return {"blocks": blocks}
+
+
+def _blocks_from_cache_dict(client: Steamship, value: Dict[str, any]) -> List[Block]:
+    """Attempts to convert a key-store-safe dictionary to a list of blocks.
+
+    Convention: {'blocks':[{'id': <block_id>}, {'text': <some_text>}]}
+    """
+    if block_list := value.get("blocks"):
+        return_blocks = []
+        for b in block_list:
+            if block_id := b.get("id"):
+                return_blocks.append(Block.get(client, _id=block_id))
+            else:
+                return_blocks.append(Block(text=b.get("text"), mime_type=MimeTypes.TXT))
+        return return_blocks
+
+    return []
+
+
+class ActionCache:
+    """Provide persistent cache layer for AgentContext that allows lookups of output blocks from Actions.
+
+    Use this cache to eliminate calls to Tools.
+
+    NOTE: EXPERIMENTAL.
+    """
+
+    client: Steamship
+    key_value_store: KeyValueStore
+
+    def __init__(self, client: Steamship, key_value_store: KeyValueStore):
+        self.client = client
+        self.key_value_store = key_value_store
+
+    @staticmethod
+    def get_or_create(client: Steamship, context_keys: Dict[str, str]):
+        cache_handle = (
+            f"actioncache-{hashlib.sha256(json.dumps(context_keys).encode('utf-8')).hexdigest()}"
+        )
+        return ActionCache(
+            client=client,
+            key_value_store=KeyValueStore(client=client, store_identifier=cache_handle),
+        )
+
+    @staticmethod
+    def _cache_key_for(action: Action) -> str:
+        if isinstance(action, Action):
+            key = f"{action.tool}"
+            for block in action.input:
+                if block.is_text():
+                    key = f"{key}-{block.text}"
+                else:
+                    key = f"{key}-{block.id}"
+        else:
+            key = f"unknown-{json.dumps(action)}"
+
+        return f"sk-{hashlib.sha256(key.encode('utf-8')).hexdigest()}"
+
+    def lookup(self, key: Action) -> Optional[List[Block]]:
+        cache_key = ActionCache._cache_key_for(key)
+        value = self.key_value_store.get(key=cache_key) or None
+        if value:
+            logging.debug(f"cache hit for {cache_key}")
+            return _blocks_from_cache_dict(self.client, value)
+
+        logging.debug(f"cache miss for {cache_key}")
+        return None
+
+    def clear(self) -> None:
+        self.key_value_store.reset()
+
+    def update(self, key: Action, value: List[Block]):
+        # TODO: should this be synchronous and wait?
+        self.key_value_store.set(
+            key=ActionCache._cache_key_for(key), value=_blocks_to_cache_dict(value)
+        )
+        return
+
+    def delete(self, key: Action) -> bool:
+        return self.key_value_store.delete(key=ActionCache._cache_key_for(key))
+
+
+class LLMCache:
+    """Provide persistent cache layer for AgentContext that allows lookups of Actions from LLM prompts.
+
+    Use this cache to eliminate calls to LLMs for Tool selection and direct responses.
+
+    NOTE: EXPERIMENTAL.
+    """
+
+    client: Steamship
+    key_value_store: KeyValueStore
+
+    def __init__(self, client: Steamship, key_value_store: KeyValueStore):
+        self.client = client
+        self.key_value_store = key_value_store
+
+    @staticmethod
+    def get_or_create(client: Steamship, context_keys: Dict[str, str]):
+        cache_handle = (
+            f"llmcache-{hashlib.sha256(json.dumps(context_keys).encode('utf-8')).hexdigest()}"
+        )
+        return LLMCache(
+            client=client,
+            key_value_store=KeyValueStore(client=client, store_identifier=cache_handle),
+        )
+
+    @staticmethod
+    def _cache_key_for(inputs: List[Block]) -> str:
+        if isinstance(inputs, list):
+            key = "llm"
+            for block in inputs:
+                if block.is_text():
+                    key = f"{key}-{block.text}"
+                else:
+                    key = f"{key}-{block.id}"
+        else:
+            key = f"unknown-{json.dumps(inputs)}"
+        return f"sk-{hashlib.sha256(key.encode('utf-8')).hexdigest()}"
+
+    def _action_from_value(self, value: dict) -> Action:
+        input_blocks = []
+        if in_blocks := value.get("input"):
+            input_blocks = _blocks_from_cache_dict(self.client, in_blocks)
+
+        output_blocks = []
+        if out_blocks := value.get("output"):
+            output_blocks = _blocks_from_cache_dict(self.client, out_blocks)
+
+        if value.get("tool") == "Agent-FinishAction":
+            return FinishAction(input=input_blocks, output=output_blocks)
+
+        return Action(tool=value.get("tool"), input=input_blocks, output=output_blocks)
+
+    def lookup(self, key: List[Block]) -> Optional[Action]:
+        cache_key = LLMCache._cache_key_for(key)
+        value = self.key_value_store.get(key=cache_key) or None
+        if value:
+            logging.debug(f"cache hit for {cache_key}")
+            return self._action_from_value(value)
+
+        logging.debug(f"cache miss for {cache_key}")
+        return None
+
+    def clear(self) -> None:
+        self.key_value_store.reset()
+
+    def update(self, key: List[Block], value: Action):
+        # TODO: should this be synchronous and wait?
+        action_dict = {
+            "tool": value.tool,
+            "input": _blocks_to_cache_dict(value.input),
+            "output": _blocks_to_cache_dict(value.output),
+        }
+        self.key_value_store.set(key=LLMCache._cache_key_for(key), value=action_dict)
+        return
+
+    def delete(self, key: List[Block]) -> bool:
+        return self.key_value_store.delete(key=LLMCache._cache_key_for(key))

--- a/src/steamship/agents/schema/context.py
+++ b/src/steamship/agents/schema/context.py
@@ -39,11 +39,11 @@ class AgentContext:
     """Called when an agent execution has completed. These provide a way for the AgentService
     to return the result of an agent execution to the package that requested the agent execution."""
 
-    action_cache: ActionCache
+    action_cache: Optional[ActionCache]
     """Caches all interations with Tools within a Context. This provides a way to avoid duplicated
     calls to Tools when within the same context."""
 
-    llm_cache: LLMCache
+    llm_cache: Optional[LLMCache]
     """Caches all interations with LLMs within a Context. This provides a way to avoid duplicated
     calls to LLMs when within the same context."""
 

--- a/src/steamship/agents/service/agent_service.py
+++ b/src/steamship/agents/service/agent_service.py
@@ -39,7 +39,17 @@ class AgentService(PackageService):
         action: Action = None
         if context.llm_cache:
             action = context.llm_cache.lookup(key=input_blocks)
-        if not action:
+        if action:
+            logging.info(
+                f"Using cached response: calling {action.tool}.",
+                extra={
+                    AgentLogging.TOOL_NAME: "LLM",
+                    AgentLogging.IS_MESSAGE: True,
+                    AgentLogging.MESSAGE_TYPE: AgentLogging.OBSERVATION,
+                    AgentLogging.MESSAGE_AUTHOR: AgentLogging.AGENT,
+                },
+            )
+        else:
             inputs = ",".join([f"{b.as_llm_input()}" for b in input_blocks])
             logging.info(
                 f"Prompting LLM with: ({inputs})",

--- a/src/steamship/agents/service/agent_service.py
+++ b/src/steamship/agents/service/agent_service.py
@@ -15,18 +15,90 @@ class AgentService(PackageService):
     """AgentService is a Steamship Package that can use an Agent, Tools, and a provided AgentContext to
     respond to user input."""
 
-    def __init__(self, **kwargs):
+    use_llm_cache: bool
+    """Whether or not to cache LLM calls (for tool selection/direct responses) by default."""
+
+    use_action_cache: bool
+    """Whether or not to cache agent Actions (for tool runs) by default."""
+
+    def __init__(
+        self,
+        use_llm_cache: Optional[bool] = False,
+        use_action_cache: Optional[bool] = False,
+        **kwargs,
+    ):
+        self.use_llm_cache = use_llm_cache
+        self.use_action_cache = use_action_cache
         super().__init__(**kwargs)
 
     ###############################################
     # Tool selection / execution
     ###############################################
 
-    def run_action(self, action: Action, context: AgentContext):
+    def next_action(self, agent: Agent, input_blocks: List[Block], context: AgentContext) -> Action:
+        action: Action = None
+        if context.llm_cache:
+            action = context.llm_cache.lookup(key=input_blocks)
+        if not action:
+            inputs = ",".join([f"{b.as_llm_input()}" for b in input_blocks])
+            logging.info(
+                f"Prompting LLM with: ({inputs})",
+                extra={
+                    AgentLogging.TOOL_NAME: "LLM",
+                    AgentLogging.IS_MESSAGE: True,
+                    AgentLogging.MESSAGE_TYPE: AgentLogging.PROMPT,
+                    AgentLogging.MESSAGE_AUTHOR: AgentLogging.AGENT,
+                },
+            )
+            action = agent.next_action(context=context)
+            if context.llm_cache:
+                context.llm_cache.update(key=input_blocks, value=action)
+        return action
+
+    def run_action(self, agent: Agent, action: Action, context: AgentContext):
         if isinstance(action, FinishAction):
             return
 
-        blocks_or_task = action.tool.run(tool_input=action.input, context=context)
+        if not agent:
+            raise SteamshipError(
+                "Missing agent. Not able to run action on behalf of missing agent."
+            )
+
+        if context.action_cache:
+            # if cache and action is cached, use it. otherwise proceed normally.
+            if output_blocks := context.action_cache.lookup(key=action):
+                outputs = ",".join([f"{b.as_llm_input()}" for b in output_blocks])
+                logging.info(
+                    f"Tool {action.tool}: ({outputs}) [cached]",
+                    extra={
+                        AgentLogging.TOOL_NAME: action.tool,
+                        AgentLogging.IS_MESSAGE: True,
+                        AgentLogging.MESSAGE_TYPE: AgentLogging.OBSERVATION,
+                        AgentLogging.MESSAGE_AUTHOR: AgentLogging.AGENT,
+                    },
+                )
+                action.output = output_blocks
+                context.completed_steps.append(action)
+                return
+
+        tool = next((tool for tool in agent.tools if tool.name == action.tool), None)
+        if not tool:
+            raise SteamshipError(
+                f"Could not find tool '{action.tool}' for action. Not able to run."
+            )
+
+        # TODO: Arrive at a solid design for the details of this structured log object
+        inputs = ",".join([f"{b.as_llm_input()}" for b in action.input])
+        logging.info(
+            f"Running Tool {action.tool} ({inputs})",
+            extra={
+                AgentLogging.TOOL_NAME: action.tool,
+                AgentLogging.IS_MESSAGE: True,
+                AgentLogging.MESSAGE_TYPE: AgentLogging.ACTION,
+                AgentLogging.MESSAGE_AUTHOR: AgentLogging.AGENT,
+            },
+        )
+        blocks_or_task = tool.run(tool_input=action.input, context=context)
         if isinstance(blocks_or_task, Task):
             raise SteamshipError(
                 "Tools return Tasks are not yet supported (but will be soon). "
@@ -35,9 +107,9 @@ class AgentService(PackageService):
         else:
             outputs = ",".join([f"{b.as_llm_input()}" for b in blocks_or_task])
             logging.info(
-                f"Tool {action.tool.name}: ({outputs})",
+                f"Tool {action.tool}: ({outputs})",
                 extra={
-                    AgentLogging.TOOL_NAME: action.tool.name,
+                    AgentLogging.TOOL_NAME: action.tool,
                     AgentLogging.IS_MESSAGE: True,
                     AgentLogging.MESSAGE_TYPE: AgentLogging.OBSERVATION,
                     AgentLogging.MESSAGE_AUTHOR: AgentLogging.AGENT,
@@ -45,31 +117,27 @@ class AgentService(PackageService):
             )
             action.output = blocks_or_task
             context.completed_steps.append(action)
+            if context.action_cache:
+                context.action_cache.update(key=action, value=action.output)
 
     def run_agent(self, agent: Agent, context: AgentContext):
         # first, clear any prior agent steps from set of completed steps
         # this will allow the agent to select tools/dispatch actions based on a new context
         context.completed_steps = []
-        action = agent.next_action(context=context)
+
+        action = self.next_action(
+            agent=agent, input_blocks=[context.chat_history.last_user_message], context=context
+        )
+
         while not isinstance(action, FinishAction):
-            # TODO: Arrive at a solid design for the details of this structured log object
-            inputs = ",".join([f"{b.as_llm_input()}" for b in action.input])
-            logging.info(
-                f"Running Tool {action.tool.name} ({inputs})",
-                extra={
-                    AgentLogging.TOOL_NAME: action.tool.name,
-                    AgentLogging.IS_MESSAGE: True,
-                    AgentLogging.MESSAGE_TYPE: AgentLogging.ACTION,
-                    AgentLogging.MESSAGE_AUTHOR: AgentLogging.AGENT,
-                },
-            )
-            self.run_action(action=action, context=context)
-            action = agent.next_action(context=context)
+            self.run_action(agent=agent, action=action, context=context)
+            action = self.next_action(agent=agent, input_blocks=action.output, context=context)
+
             # TODO: Arrive at a solid design for the details of this structured log object
             logging.info(
-                f"Next Tool: {action.tool.name}",
+                f"Next Tool: {action.tool}",
                 extra={
-                    AgentLogging.TOOL_NAME: action.tool.name,
+                    AgentLogging.TOOL_NAME: action.tool,
                     AgentLogging.IS_MESSAGE: False,
                     AgentLogging.MESSAGE_TYPE: AgentLogging.ACTION,
                     AgentLogging.MESSAGE_AUTHOR: AgentLogging.AGENT,
@@ -102,7 +170,20 @@ class AgentService(PackageService):
                 f"No context_id was provided; generated {context_id}. This likely means no conversational history will be present."
             )
 
-        context = AgentContext.get_or_create(self.client, context_keys={"id": f"{context_id}"})
+        use_llm_cache = self.use_llm_cache
+        if runtime_use_llm_cache := kwargs.get("use_llm_cache"):
+            use_llm_cache = runtime_use_llm_cache
+
+        use_action_cache = self.use_action_cache
+        if runtime_use_action_cache := kwargs.get("use_action_cache"):
+            use_action_cache = runtime_use_action_cache
+
+        context = AgentContext.get_or_create(
+            client=self.client,
+            context_keys={"id": f"{context_id}"},
+            use_llm_cache=use_llm_cache,
+            use_action_cache=use_action_cache,
+        )
         context.chat_history.append_user_message(prompt)
 
         # Add a default LLM

--- a/tests/steamship_tests/agents/test_agent_service.py
+++ b/tests/steamship_tests/agents/test_agent_service.py
@@ -1,0 +1,64 @@
+from typing import List
+
+import pytest
+from steamship_tests import SRC_PATH
+from steamship_tests.utils.deployables import deploy_package
+
+from steamship import Block, Steamship, SteamshipError
+from steamship.agents.schema import Action, AgentContext
+
+
+def _blocks_from_invoke(client: Steamship, potential_blocks) -> List[Block]:
+    try:
+        if isinstance(potential_blocks, list):
+            return [Block(client=client, **raw) for raw in potential_blocks]
+        else:
+            return [Block(client=client, **potential_blocks)]
+    except Exception as e:
+        raise SteamshipError(f"Could not convert to blocks: {e}")
+
+
+@pytest.mark.usefixtures("client")
+def test_example_with_caching_service(client: Steamship):
+
+    # TODO(dougreid): replace the example agent with fake/free/fast tools to minimize test time / costs?
+
+    example_caching_agent_path = (
+        SRC_PATH / "steamship" / "agents" / "examples" / "example_assistant_with_caching.py"
+    )
+    with deploy_package(client, example_caching_agent_path) as (_, _, caching_agent):
+        context_id = "foo-test-caching"
+        context_keys = {"id": context_id}
+
+        # attempt without caching
+        blocks_json = caching_agent.invoke("prompt", prompt="draw a cat", context_id=context_id)
+        assert blocks_json
+        blocks = _blocks_from_invoke(client, blocks_json)
+        assert len(blocks) == 2
+        assert "image" in blocks[0].text
+        assert blocks[1].is_image()
+
+        agent_context = AgentContext.get_or_create(
+            client=client, context_keys=context_keys, use_llm_cache=True, use_action_cache=True
+        )
+        # just clear the cache to start fresh
+        agent_context.llm_cache.clear()
+        agent_context.action_cache.clear()
+
+        fake_action = Action(tool="fake_tool", input=[Block(text="a cat")])
+        agent_context.llm_cache.update(key=[Block(text="draw a cat")], value=fake_action)
+
+        fake_output = [Block(text="psyche")]
+        agent_context.action_cache.update(key=fake_action, value=fake_output)
+
+        fake_finish_action = Action(
+            tool="Agent-FinishAction", input=[], output=[Block(text="insert cat image here")]
+        )
+        agent_context.llm_cache.update(key=fake_output, value=fake_finish_action)
+
+        # now attempt with the caching
+        blocks_json = caching_agent.invoke("prompt", prompt="draw a cat", context_id=context_id)
+        assert blocks_json
+        blocks = _blocks_from_invoke(client, blocks_json)
+        assert len(blocks) == 1
+        assert "insert cat image here" == blocks[0].text

--- a/tests/steamship_tests/agents/test_cache.py
+++ b/tests/steamship_tests/agents/test_cache.py
@@ -1,0 +1,75 @@
+import pytest
+
+from steamship import Block, File, MimeTypes, Steamship
+from steamship.agents.schema import Action
+from steamship.agents.schema.cache import ActionCache, LLMCache
+
+
+@pytest.mark.usefixtures("client")
+def test_llm_cache(client: Steamship):
+    context_keys = {"id": "test"}
+    cache = LLMCache.get_or_create(client=client, context_keys=context_keys)
+
+    key = [Block(text="prompt")]
+    assert not cache.lookup(key)
+
+    cache.update(key=key, value=Action(tool="example_tool", input=[Block(text="input")]))
+    action = cache.lookup(key)
+    assert action
+    assert action.tool == "example_tool"
+    assert action.input[0].text == "input"
+
+    cache.update(key=key, value=Action(tool="example_tool", input=[Block(text="other")]))
+    action = cache.lookup(key)
+    assert action
+    assert action.tool == "example_tool"
+    assert action.input[0].text == "other"
+
+    cache.delete(key)
+    assert not cache.lookup(key)
+
+    file = File.create(client=client, handle="whocares")
+    fake_image_block = Block.create(
+        client, file_id=file.id, content=bytes([1, 3, 5]), mime_type=MimeTypes.PNG
+    )
+    text_and_image_key = [Block(text="caption this", mime_type=MimeTypes.TXT), fake_image_block]
+    image_action = Action(tool="image_tool", input=text_and_image_key)
+    cache.update(key=text_and_image_key, value=image_action)
+    action = cache.lookup(key=text_and_image_key)
+    assert action
+    assert action.tool == "image_tool"
+    assert action.input == text_and_image_key
+
+    cache.clear()
+    assert not cache.lookup(key=text_and_image_key)
+
+
+@pytest.mark.usefixtures("client")
+def test_action_cache(client: Steamship):
+    context_keys = {"id": "test"}
+    cache = ActionCache.get_or_create(client=client, context_keys=context_keys)
+
+    file = File.create(client=client, handle="whocares")
+    fake_image_block = Block.create(
+        client, file_id=file.id, content=bytes([1, 3, 5]), mime_type=MimeTypes.PNG
+    )
+    text_and_image = [Block(text="caption this", mime_type=MimeTypes.TXT), fake_image_block]
+    key = Action(tool="fake_tool", input=text_and_image)
+    assert not cache.lookup(key)
+
+    cache.update(key=key, value=text_and_image)
+    blocks = cache.lookup(key)
+    assert blocks
+    assert blocks == text_and_image
+
+    cache.update(key=key, value=[Block(text="other")])
+    blocks = cache.lookup(key)
+    assert blocks
+    assert blocks[0].text == "other"
+
+    cache.delete(key)
+    assert not cache.lookup(key)
+
+    cache.update(key=key, value=text_and_image)
+    cache.clear()
+    assert not cache.lookup(key)

--- a/tests/steamship_tests/agents/test_functions_based_agent.py
+++ b/tests/steamship_tests/agents/test_functions_based_agent.py
@@ -33,7 +33,7 @@ def test_functions_based_agent_single_tool_selection_with_no_memory(client: Stea
 
     action = agent.next_action(context=ctx)
     assert not isinstance(action, FinishAction)
-    assert action.tool.name == "SearchTool"
+    assert action.tool == "SearchTool"
 
 
 @pytest.mark.usefixtures("client")
@@ -48,7 +48,7 @@ def test_functions_based_agent_multimodal_tool_selection_with_no_memory(client: 
 
     action = agent.next_action(context=ctx)
     assert not isinstance(action, FinishAction)
-    assert action.tool.name == "DalleTool"
+    assert action.tool == "DalleTool"
 
 
 @pytest.mark.usefixtures("client")
@@ -82,14 +82,14 @@ def test_functions_based_agent_tool_chaining_without_memory(client: Steamship):
 
     action = agent.next_action(context=ctx)
     assert not isinstance(action, FinishAction)
-    assert action.tool.name == "SearchTool"
+    assert action.tool == "SearchTool"
 
     action.output.append(Block(text="George Washington"))
     ctx.completed_steps.append(action)
 
     second_action = agent.next_action(context=ctx)
     assert not isinstance(second_action, FinishAction)
-    assert second_action.tool.name == "DalleTool"
+    assert second_action.tool == "DalleTool"
 
 
 @pytest.mark.usefixtures("client")
@@ -106,7 +106,7 @@ def test_functions_based_agent_tools_with_memory(client: Steamship):
 
     action = agent.next_action(context=ctx)
     assert not isinstance(action, FinishAction)
-    assert action.tool.name == "SearchTool"
+    assert action.tool == "SearchTool"
 
     ctx.chat_history.append_assistant_message("Tsai Ing-wen")
     ctx.completed_steps = []
@@ -115,7 +115,7 @@ def test_functions_based_agent_tools_with_memory(client: Steamship):
 
     second_action = agent.next_action(context=ctx)
     assert not isinstance(second_action, FinishAction)
-    assert second_action.tool.name == "DalleTool"
+    assert second_action.tool == "DalleTool"
 
     found = False
     for block in second_action.input:

--- a/tests/steamship_tests/agents/test_functions_based_agent.py
+++ b/tests/steamship_tests/agents/test_functions_based_agent.py
@@ -84,6 +84,9 @@ def test_functions_based_agent_tool_chaining_without_memory(client: Steamship):
     assert not isinstance(action, FinishAction)
     assert action.tool == "SearchTool"
 
+    if not action.output:
+        action.output = []
+
     action.output.append(Block(text="George Washington"))
     ctx.completed_steps.append(action)
 


### PR DESCRIPTION
This is an initial PR for adding caching functionality to Agents. It is aimed at reducing cost and latency for repeated requests.

It attempts to provide two levels of caching:
(1) prompts to the LLMs (prompt-to-Action cache) and (2) action executions (Action-to-outputs cache).

Cache behavior can be dynamically control per call to `prompt`.

NOTE: This PR is NOT introducing semantic caches (text/block uuids must match precisely).
FOLLOW-ONS: Allow Tool-default opt-in/opt-out of caching