### PR TITLE
Make Telegram optional

### DIFF
--- a/src/steamship/agents/mixins/transports/telegram.py
+++ b/src/steamship/agents/mixins/transports/telegram.py
@@ -12,6 +12,7 @@ from steamship.agents.schema import Agent, AgentContext, EmitFunc, Metadata
 from steamship.agents.service.agent_service import AgentService
 from steamship.agents.utils import with_llm
 from steamship.invocable import Config, InvocableResponse, InvocationContext, post
+from steamship.utils.kv_store import KeyValueStore
 
 
 class TelegramTransportConfig(Config):
@@ -28,19 +29,32 @@ class TelegramTransport(Transport):
     agent_service: AgentService
 
     def __init__(
-        self,
-        client: Steamship,
-        config: TelegramTransportConfig,
-        agent_service: AgentService,
-        agent: Agent,
+            self,
+            client: Steamship,
+            config: TelegramTransportConfig,
+            agent_service: AgentService,
+            agent: Agent,
     ):
         super().__init__(client=client)
-        self.api_root = f"{config.api_base}{config.bot_token}"
-        self.bot_token = config.bot_token
+
+        self.store = KeyValueStore(self.client, store_identifier="_telegram_config")
+        bot_token = (self.store.get("bot_token") or {}).get("token")
+        self.bot_token = config.bot_token or bot_token
+        self.api_root = f"{config.api_base}{self.bot_token}"
         self.agent = agent
         self.agent_service = agent_service
 
     def instance_init(self, config: Config, invocation_context: InvocationContext):
+        if self.bot_token:
+            self.api_root = f"{config.api_base}{config.bot_token or self.bot_token}"
+            try:
+                self._instance_init(
+                    config=config, invocation_context=invocation_context
+                )
+            except Exception:
+                pass
+
+    def _instance_init(self, config: Config, invocation_context: InvocationContext):
         webhook_url = invocation_context.invocable_url + "telegram_respond"
 
         logging.info(
@@ -64,6 +78,17 @@ class TelegramTransport(Transport):
     @post("telegram_webhook_info")
     def telegram_webhook_info(self) -> dict:
         return requests.get(self.api_root + "/getWebhookInfo").json()
+
+    @post("connect_telegram")
+    def connect_telegram(self, bot_token: str):
+        self.store.set("bot_token", {"token": bot_token})
+        self.bot_token = bot_token
+
+        try:
+            self.instance_init(self.agent_service.config, self.agent_service.context)
+            return "OK"
+        except Exception as e:
+            return f"Could not set webhook for bot. Exception: {e}"
 
     @post("telegram_disconnect_webhook")
     def telegram_disconnect_webhook(self, *args, **kwargs):

--- a/src/steamship/agents/mixins/transports/telegram.py
+++ b/src/steamship/agents/mixins/transports/telegram.py
@@ -29,11 +29,11 @@ class TelegramTransport(Transport):
     agent_service: AgentService
 
     def __init__(
-            self,
-            client: Steamship,
-            config: TelegramTransportConfig,
-            agent_service: AgentService,
-            agent: Agent,
+        self,
+        client: Steamship,
+        config: TelegramTransportConfig,
+        agent_service: AgentService,
+        agent: Agent,
     ):
         super().__init__(client=client)
 

--- a/src/steamship/agents/mixins/transports/telegram.py
+++ b/src/steamship/agents/mixins/transports/telegram.py
@@ -48,10 +48,8 @@ class TelegramTransport(Transport):
         if self.bot_token:
             self.api_root = f"{config.api_base}{config.bot_token or self.bot_token}"
             try:
-                self._instance_init(
-                    config=config, invocation_context=invocation_context
-                )
-            except Exception:
+                self._instance_init(config=config, invocation_context=invocation_context)
+            except Exception:  # noqa: S110
                 pass
 
     def _instance_init(self, config: Config, invocation_context: InvocationContext):


### PR DESCRIPTION
This PR makes the bot_token optional when using the TelegramMixin. 

* bot_token can be updated with the auth-protected `connect_telegram` route 
* bot_tokens are either passed via the internal kv store OR the config 
* config bot_token takes precedence over the kv-stored bot_token
* Note: kv store is used since config is idempotent. 