### PR TITLE
[SHIP-793] Allow tags to be returned in File Importers

### DIFF
--- a/src/steamship/plugin/outputs/raw_data_plugin_output.py
+++ b/src/steamship/plugin/outputs/raw_data_plugin_output.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import io
-from typing import Any, Optional, Type, Union
+from typing import Any, List, Optional, Type, Union
 
 from pydantic import BaseModel
 
+from steamship import Tag
 from steamship.base import MimeTypes
 from steamship.plugin.outputs.plugin_output import PluginOutput
 from steamship.utils.binary_utils import flexi_create
@@ -30,6 +31,7 @@ class RawDataPluginOutput(PluginOutput):
 
     data: Optional[str] = None  # Note: This is **always** Base64 encoded.
     mime_type: Optional[str] = None
+    tags: Optional[List[Tag]] = None
 
     def __init__(
         self,
@@ -38,10 +40,11 @@ class RawDataPluginOutput(PluginOutput):
         _bytes: Union[bytes, io.BytesIO] = None,
         json: Any = None,
         mime_type: str = None,
+        tags: Optional[List[Tag]] = None,
         **kwargs,
     ):
         super().__init__()
-
+        self.tags = tags
         if base64string is not None:
             self.data = base64string
             self.mime_type = mime_type or MimeTypes.BINARY

--- a/tests/assets/plugins/importers/plugin_file_importer.py
+++ b/tests/assets/plugins/importers/plugin_file_importer.py
@@ -1,4 +1,4 @@
-from steamship import MimeTypes
+from steamship import MimeTypes, Tag
 from steamship.invocable import InvocableResponse, create_handler
 from steamship.invocable.plugin_service import PluginRequest
 from steamship.plugin.file_importer import FileImporter
@@ -18,7 +18,13 @@ class TestFileImporterPlugin(FileImporter):
     def run(
         self, request: PluginRequest[FileImportPluginInput]
     ) -> InvocableResponse[RawDataPluginOutput]:
-        return InvocableResponse(data=RawDataPluginOutput(string=TEST_DOC, mime_type=MimeTypes.MKD))
+        return InvocableResponse(
+            data=RawDataPluginOutput(
+                string=TEST_DOC,
+                mime_type=MimeTypes.MKD,
+                tags=[Tag(kind="test-kind", name="test-name")],
+            )
+        )
 
 
 handler = create_handler(TestFileImporterPlugin)

--- a/tests/steamship_tests/plugin/integration/test_e2e_file_importer.py
+++ b/tests/steamship_tests/plugin/integration/test_e2e_file_importer.py
@@ -16,11 +16,20 @@ def test_e2e_importer(client: Steamship):
         instance,
     ):
         # The test FileImporter should always return a string file with contents TEST_DOC
-        file = File.create_with_plugin(client=client, plugin_instance=instance.handle)
-        file.wait()
-        file = file.output
+        file_task = File.create_with_plugin(client=client, plugin_instance=instance.handle)
+        file = file_task.wait()
+
+        assert len(file.tags) == 1
+        assert file.tags[0].kind == "test-kind"
+        assert file.tags[0].name == "test-name"
+
         # Now fetch the data from Steamship and assert that it is the SAME as the data the FileImporter creates
         data = file.raw()
         assert data.decode("utf-8") == TEST_DOC
+
+        fetched_file = File.get(client, _id=file.id)
+        assert len(fetched_file.tags) == 1
+        assert fetched_file.tags[0].kind == "test-kind"
+        assert fetched_file.tags[0].name == "test-name"
 
         file.delete()


### PR DESCRIPTION
Depends on https://github.com/nludb/nludb/pull/600

Allow FileImporters to return tags in the RawDataPluginOutput.