### PR TITLE
Support engine-registered development runs in the client

### DIFF
--- a/src/steamship/base/mime_types.py
+++ b/src/steamship/base/mime_types.py
@@ -36,6 +36,7 @@ class MimeTypes(str, Enum):
 
     @classmethod
     def is_binary(cls, value):
+        """Returns whether the mime type is likely a binary file."""
         return value in [
             cls.UNKNOWN,
             cls.PDF,

--- a/src/steamship/base/mime_types.py
+++ b/src/steamship/base/mime_types.py
@@ -34,6 +34,28 @@ class MimeTypes(str, Enum):
     def has_value(cls, value):
         return value in cls._value2member_map_
 
+    @classmethod
+    def is_binary(cls, value):
+        return value in [
+            cls.UNKNOWN,
+            cls.PDF,
+            cls.JPG,
+            cls.PNG,
+            cls.TIFF,
+            cls.GIF,
+            cls.DOC,
+            cls.PPT,
+            cls.BINARY,
+            cls.WAV,
+            cls.MP3,
+            cls.OGG_VIDEO,
+            cls.OGG_AUDIO,
+            cls.MP4_AUDIO,
+            cls.MP4_VIDEO,
+            cls.WEBM_AUDIO,
+            cls.WEBM_VIDEO,
+        ]
+
 
 class ContentEncodings:
     BASE64 = "base64"

--- a/src/steamship/base/tasks.py
+++ b/src/steamship/base/tasks.py
@@ -205,12 +205,9 @@ class Task(GenericCamelModel, Generic[T]):
 
     def update(self, other: Optional[Task] = None):
         """Incorporates a `Task` into this object."""
-        print("UPdating")
         other = other or Task()
         for k, v in other.__dict__.items():
-            print("k", k, "v", v)
             self.__dict__[k] = v
-        print("UPdated")
 
     def add_comment(
         self,

--- a/src/steamship/base/tasks.py
+++ b/src/steamship/base/tasks.py
@@ -205,9 +205,12 @@ class Task(GenericCamelModel, Generic[T]):
 
     def update(self, other: Optional[Task] = None):
         """Incorporates a `Task` into this object."""
+        print("UPdating")
         other = other or Task()
         for k, v in other.__dict__.items():
+            print("k", k, "v", v)
             self.__dict__[k] = v
+        print("UPdated")
 
     def add_comment(
         self,

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -307,14 +307,11 @@ def serve_local(  # noqa: C901
             config=config,
         )
 
-        # It's not registered_instance.invocation_url because that ends up being the local url!
-        # We need to construct the URL dynamically
-        # user_handle = user.handle
-        # app_url = client.config.app_base.replace("//", f"//{user_handle}.")
-        # if app_url[-1] != "/":
-        #     app_url = app_url + "/"
-        #
-        # public_api_url = f"{app_url}{workspace}/{registered_instance.handle}"
+        # Notes:
+        #  1. registered_instance.invocation_url is the NGROK URL, not the Steamship Proxy URL.
+        #  2. The public_api_url should still be NGROK, not the Proxy. The local server emulates the Proxy and
+        #     the Proxy blocks this kind of development traffic.
+
         public_api_url = ngrok_api_url
         click.secho(f"🌎 Public API: {public_api_url}")
 

--- a/src/steamship/data/package/package_instance.py
+++ b/src/steamship/data/package/package_instance.py
@@ -15,7 +15,7 @@ from steamship.data.workspace import Workspace
 from steamship.utils.url import Verb
 
 LOCAL_DEVELOPMENT_VERSION_HANDLE = (
-    "local-development"  # Special handle for a locally-running development instances.
+    "local-development!"  # Special handle for a locally-running development instances.
 )
 
 

--- a/src/steamship/data/package/package_instance.py
+++ b/src/steamship/data/package/package_instance.py
@@ -14,6 +14,10 @@ from steamship.data.invocable_init_status import InvocableInitStatus
 from steamship.data.workspace import Workspace
 from steamship.utils.url import Verb
 
+LOCAL_DEVELOPMENT_VERSION_HANDLE = (
+    "local-development"  # Special handle for a locally-running development instances.
+)
+
 
 class CreatePackageInstanceRequest(Request):
     id: str = None
@@ -25,6 +29,12 @@ class CreatePackageInstanceRequest(Request):
     fetch_if_exists: bool = None
     config: Dict[str, Any] = None
     workspace_id: str = None
+
+    local_development_url: Optional[str] = None
+    """Special argument only intended for creating an PackageInstance bound to a local development server.
+
+    If used, the package_version_handle should be set to LOCAL_DEVELOPMENT_VERSION_HANDLE above.
+    """
 
 
 class PackageInstance(CamelModel):
@@ -70,6 +80,28 @@ class PackageInstance(CamelModel):
             config=config,
         )
 
+        return client.post("package/instance/create", payload=req, expect=PackageInstance)
+
+    @staticmethod
+    def create_local_development_instance(
+        client: Client,
+        local_development_url: str,
+        package_id: str = None,
+        package_handle: str = None,
+        handle: str = None,
+        fetch_if_exists: bool = True,
+        config: Dict[str, Any] = None,
+    ) -> PackageInstance:
+        req = CreatePackageInstanceRequest(
+            handle=handle,
+            package_id=package_id,
+            package_handle=package_handle,
+            package_version_handle=LOCAL_DEVELOPMENT_VERSION_HANDLE,
+            fetch_if_exists=fetch_if_exists,
+            config=config,
+            local_development_url=local_development_url,
+        )
+        """Create a PackageInstance bound to a local development server."""
         return client.post("package/instance/create", payload=req, expect=PackageInstance)
 
     def delete(self) -> PackageInstance:

--- a/src/steamship/utils/repl.py
+++ b/src/steamship/utils/repl.py
@@ -246,17 +246,25 @@ class HttpREPL(SteamshipREPL):
                 logging.exception(ex)
 
             if result:
-                if result.get("status", {}).get("state", None) == TaskState.failed:
-                    message = result.get("status", {}).get("status_message", None)
-                    logging.error(f"Response failed with remote error: {message or 'No message'}")
-                    if suggestion := result.get("status", {}).get("status_suggestion", None):
-                        logging.error(f"Suggestion: {suggestion}")
-                elif data := result.get("data", None):
-                    self.print_object_or_objects(data)
+                if isinstance(result, dict):
+                    if result.get("status", {}).get("state", None) == TaskState.failed:
+                        message = result.get("status", {}).get("status_message", None)
+                        logging.error(
+                            f"Response failed with remote error: {message or 'No message'}"
+                        )
+                        if suggestion := result.get("status", {}).get("status_suggestion", None):
+                            logging.error(f"Suggestion: {suggestion}")
+                    elif data := result.get("data", None):
+                        self.print_object_or_objects(data)
+                    else:
+                        logging.warning(
+                            "REPL interaction completed with empty data field in InvocableResponse."
+                        )
+                if isinstance(result, list):
+                    self.print_object_or_objects(result)
                 else:
-                    logging.warning(
-                        "REPL interaction completed with empty data field in InvocableResponse."
-                    )
+                    logging.warning("Unsure how to display result:")
+                    logging.warning(result)
             else:
                 logging.warning("REPL interaction completed with no result to print.")
 


### PR DESCRIPTION
- Fix response unpacking bug in local_server -- It should have been unwrapping the Service response like the Steamship Proxy
- Fix the HttpREPL, which depended upon the improperly unwrapped response (see above)
- Upon `ship run local`, register the local running NGROK URL with the Engine so that it can make async callbacks to it.