### PR TITLE
Handle None for parse_inbound

### DIFF
--- a/src/steamship/agents/mixins/transports/transport.py
+++ b/src/steamship/agents/mixins/transports/transport.py
@@ -56,6 +56,8 @@ class Transport(PackageMixin, ABC):
 
     def parse_inbound(self, payload: dict, context: Optional[dict] = None) -> Optional[Block]:
         message = self._parse_inbound(payload, context)
+        if not message:
+            return None
 
         if message.url and not message.text:
             context = AgentContext()


### PR DESCRIPTION
parse_inbound takes the `message` from `self._parse_inbound`, which can in some cases be None, causing issues when we try to access `.url` and `.text` off it.