### PR TITLE
bugfix: Agents should only respond to unresponded-to user messages

### DIFF
--- a/src/steamship/data/tags/tag_constants.py
+++ b/src/steamship/data/tags/tag_constants.py
@@ -278,3 +278,6 @@ class ChatTag(str, Enum):
 
     # A chunk of text for indexing
     CHUNK = "chunk"
+
+    # Whether a response was sent
+    RESPONSE_SENT = "response-sent"

--- a/tests/steamship_tests/agents/test_agent_service.py
+++ b/tests/steamship_tests/agents/test_agent_service.py
@@ -41,6 +41,11 @@ def test_example_with_caching_service(client: Steamship):
         agent_context = AgentContext.get_or_create(
             client=client, context_keys=context_keys, use_llm_cache=True, use_action_cache=True
         )
+
+        # Make sure that the last user message was remarked as responded to
+        last_user_message = agent_context.chat_history.last_user_message
+        assert last_user_message.response_sent
+
         # just clear the cache to start fresh
         agent_context.llm_cache.clear()
         agent_context.action_cache.clear()


### PR DESCRIPTION
When `run_agent` is invoked, it locates the last user message in `context.chat_history` and responds to it regardless of whether that message has already been responded to.

This PR causes `run_agent` to exit early, doing nothing, if the last user message had already been marked as having been responded to.