### PR TITLE
RFC: Slack thread support

### DIFF
--- a/src/steamship/agents/mixins/transports/slack.py
+++ b/src/steamship/agents/mixins/transports/slack.py
@@ -370,6 +370,7 @@ class SlackTransport(Transport):
         }
         if thread_ts:
             body["thread_ts"] = thread_ts
+        logging.info(f"Post to slack: {body}")
 
         post_url = f"{self.config.slack_api_base}chat.postMessage"
 
@@ -406,6 +407,7 @@ class SlackTransport(Transport):
             )
 
             # TODO: For truly async support, this emit fn will need to be wired in at the Agent level.
+            logging.info("Context: {context_id}")
             context.emit_funcs = [self.build_emit_func(chat_id=chat_id, thread_ts=thread_ts)]
 
             # Add an LLM to the context, using the Agent's if it exists.

--- a/src/steamship/agents/mixins/transports/slack.py
+++ b/src/steamship/agents/mixins/transports/slack.py
@@ -407,7 +407,7 @@ class SlackTransport(Transport):
             )
 
             # TODO: For truly async support, this emit fn will need to be wired in at the Agent level.
-            logging.info("Context: {context_id}")
+            logging.info(f"Context: {context_id}")
             context.emit_funcs = [self.build_emit_func(chat_id=chat_id, thread_ts=thread_ts)]
 
             # Add an LLM to the context, using the Agent's if it exists.

--- a/src/steamship/agents/mixins/transports/slack.py
+++ b/src/steamship/agents/mixins/transports/slack.py
@@ -26,7 +26,7 @@ def get_block_thread_ts(block: Block) -> Optional[str]:
 
 
 def set_block_thread_ts(block: Block, thread_ts) -> None:
-    block._one_time_set_tag(tag_kind=DocTag.CHAT, tag_name="slack-threadid", string_value=thread_ts)
+    block._one_time_set_tag(tag_kind=DocTag.CHAT, tag_name="slack-threadts", string_value=thread_ts)
 
 
 class SlackElement(BaseModel):

--- a/src/steamship/agents/mixins/transports/slack.py
+++ b/src/steamship/agents/mixins/transports/slack.py
@@ -372,7 +372,6 @@ class SlackTransport(Transport):
         }
         if thread_ts:
             body["thread_ts"] = thread_ts
-        logging.info(f"Post to slack: {body}")
 
         post_url = f"{self.config.slack_api_base}chat.postMessage"
 
@@ -413,7 +412,6 @@ class SlackTransport(Transport):
             context.metadata["slack-messagets"] = incoming_message.message_id
 
             # TODO: For truly async support, this emit fn will need to be wired in at the Agent level.
-            logging.info(f"Context: {context_id}")
             context.emit_funcs = [self.build_emit_func(chat_id=chat_id, thread_ts=thread_ts)]
 
             # Add an LLM to the context, using the Agent's if it exists.

--- a/src/steamship/agents/mixins/transports/slack.py
+++ b/src/steamship/agents/mixins/transports/slack.py
@@ -406,6 +406,10 @@ class SlackTransport(Transport):
                 text=incoming_message.text, tags=incoming_message.tags
             )
 
+            context.metadata["slack-channel"] = chat_id
+            context.metadata["slack-threadts"] = thread_ts
+            context.metadata["slack-messagets"] = incoming_message.message_id
+
             # TODO: For truly async support, this emit fn will need to be wired in at the Agent level.
             logging.info(f"Context: {context_id}")
             context.emit_funcs = [self.build_emit_func(chat_id=chat_id, thread_ts=thread_ts)]


### PR DESCRIPTION
Adds knowledge of threading to the Slack Transport.

In its current form, the transport will respond to the channel ID only, which means that if you respond from a thread the transport will respond outside of it.  This adds knowledge of the `thread_ts` field to blocks, which is the `ts` of the parent message in the thread, and is specified in the `chat.postMessage` method as a way to reply to it.

Some open questions about whether context ID for the bot context should be channel or (channel,thread) tuple.

I've also noticed that the Tags representing slack metadata on those blocks seems to be getting stripped on its way down to the tool, which I'm assuming is defined behavior but I haven't traced it yet.