### PR TITLE
Update RST File, Block, and Tag references to Autodoc links

### DIFF
--- a/docs/nextra/agents/index.rst
+++ b/docs/nextra/agents/index.rst
@@ -50,4 +50,4 @@ AgentService
 The AgentService class provides a convenient way to deploy an Agent as a Steamship :ref:`Package<Packages>`.
 
 All  :class:`steamship.agents.service.agent_service.AgentService` instances contain a ``prompt(self, prompt: str, **kwargs) -> List[Block]`` method from thier base class.
-This method is the core ``chat`` loop: it accepts an inbound ``str`` in the form of a user message, and it produces a list of multimodal ``Block`` objects that contain the response.
+This method is the core ``chat`` loop: it accepts an inbound ``str`` in the form of a user message, and it produces a list of multimodal :py:class:`Block<steamship.data.block.Block>` objects that contain the response.

--- a/docs/nextra/data/blocks.rst
+++ b/docs/nextra/data/blocks.rst
@@ -5,7 +5,7 @@ Blocks
 
 Blocks are ordered chunks of content within a :ref:`File <Files>`.
 
-A ``Block`` may have raw data, plain text, or both.  The type of content is indicated by its ``mime_type``.
+A :py:class:`Block<steamship.data.block.Block>` may have raw data, plain text, or both.  The type of content is indicated by its ``mime_type``.
 Blocks can store images, videos, audio clips, or any other chunk of data.
 
 This means that different packages and plugins may choose divide files into blocks using different schemes.
@@ -16,14 +16,14 @@ The following divisions of this file into blocks are all perfectly fine:
 - Each 10 CSV rows is a block
 - The entire CSV file is one block
 
-Metadata and annotations about the content of the ``Block`` added via :ref:`Tags` on the ``Block`` .
+Metadata and annotations about the content of the :py:class:`Block<steamship.data.block.Block>` added via :ref:`Tags` on the :py:class:`Block<steamship.data.block.Block>` .
 
 .. _Creating Blocks:
 
 Creating Blocks
 ---------------
 
-Blocks may be created when creating a ``File`` by passing them in the ``blocks`` parameter, or they can be appended
+Blocks may be created when creating a :py:class:`File<steamship.data.file.File>` by passing them in the ``blocks`` parameter, or they can be appended
 to an existing file.
 
 Please see ``Block.create()`` and ``File.append_block()``.
@@ -35,7 +35,7 @@ Read the :py:class:`Block PyDoc spec here<steamship.data.block.Block>`.
 Making Block Data Public
 ------------------------
 
-If you want the raw data bytes of a ``Block`` to be publicly accessible, you can set the parameter ``public_data = True`` when calling ``Block.create()``.
+If you want the raw data bytes of a :py:class:`Block<steamship.data.block.Block>` to be publicly accessible, you can set the parameter ``public_data = True`` when calling ``Block.create()``.
 This is useful if you wish to share a generated image or audio file, or must make the content viewable in a place that cannot
-retain your Steamship API key.  You can also change the value of the ``public_data`` flag on an existing ``Block`` by calling
+retain your Steamship API key.  You can also change the value of the ``public_data`` flag on an existing :py:class:`Block<steamship.data.block.Block>` by calling
 ``Block.set_public_data``.

--- a/docs/nextra/data/files.rst
+++ b/docs/nextra/data/files.rst
@@ -6,13 +6,13 @@ Files
 Files are the top-level object for any piece of data in a workspace.
 
 Files hold bytes of raw data (with a ``mime_type``, and processed data in :ref:`Blocks`.
-A ``File`` may also have a list of :ref:`Tags` (annotations).
+A :py:class:`File<steamship.data.file.File>` may also have a list of :ref:`Tags` (annotations).
 
-To do work on a ``File``, it needs to be saved and its content must be in :ref:`Blocks`.
+To do work on a :py:class:`File<steamship.data.file.File>`, it needs to be saved and its content must be in :ref:`Blocks`.
 
 There are a few ways to accomplish this:
 
-- Create ``File`` and ``Block`` content directly (see below)
+- Create :py:class:`File<steamship.data.file.File>` and :py:class:`Block<steamship.data.block.Block>` content directly (see below)
 - Add raw data directly, then create ``Blocks`` with a :ref:`blockifier plugin<Blockifiers>`
 - Import raw data with a :ref:`File Importer<File Importers>`, then create ``Blocks`` with a :ref:`blockifier plugin<Blockifiers>`
 
@@ -33,7 +33,7 @@ Read the :py:class:`File PyDoc spec here<steamship.data.file.File>`.
 Creating Files Directly
 -----------------------
 
-The quickest way to create data is to create Files with ``Block`` content directly:
+The quickest way to create data is to create Files with :py:class:`Block<steamship.data.block.Block>` content directly:
 
 .. code-block:: python
 
@@ -47,7 +47,7 @@ The quickest way to create data is to create Files with ``Block`` content direct
 Making File Data Public
 ------------------------
 
-If you want the raw data bytes of a ``File`` to be publicly accessible, you can set the parameter ``public_data = True`` when calling ``File.create()``.
+If you want the raw data bytes of a :py:class:`File<steamship.data.file.File>` to be publicly accessible, you can set the parameter ``public_data = True`` when calling ``File.create()``.
 This is useful if you wish to share a generated image or audio file, or must make the content viewable in a place that cannot
-retain your Steamship API key.  You can also change the value of the ``public_data`` flag on an existing ``File`` by calling
+retain your Steamship API key.  You can also change the value of the ``public_data`` flag on an existing :py:class:`File<steamship.data.file.File>` by calling
 ``File.set_public_data``.

--- a/docs/nextra/data/index.rst
+++ b/docs/nextra/data/index.rst
@@ -5,9 +5,9 @@ Data Model
 
 There are only three core concepts you need to know.
 
-#. :ref:`Files` are the top level object for storing data. A ``File`` can store raw data and an ordered list of ``Blocks``.
-#. :ref:`Blocks` are chunks of content within a ``File``.  They can contain raw data and/or text, and an unordered set of ``Tags``.
-#. :ref:`Tags` are typed annotations on a ``Block`` or ``File``.
+#. :ref:`Files` are the top level object for storing data. A :py:class:`File<steamship.data.file.File>` can store raw data and an ordered list of ``Blocks``.
+#. :ref:`Blocks` are chunks of content within a :py:class:`File<steamship.data.file.File>`.  They can contain raw data and/or text, and an unordered set of ``Tags``.
+#. :ref:`Tags` are typed annotations on a :py:class:`Block<steamship.data.block.Block>` or :py:class:`File<steamship.data.file.File>`.
 
 
 The following diagram shows how data is created and used within Steamship:

--- a/docs/nextra/data/tags.rst
+++ b/docs/nextra/data/tags.rst
@@ -163,7 +163,7 @@ But Steamship actually supports two types of tags: **File Tags** and **Block Tag
 **Block Tags** annotate text within a :ref:`Block<Blocks>` object:
 
 - They are attached to the :ref:`Block<Blocks>` object (``block.tags``)
-- Their ``start_idx`` and ``end_idx`` fields are either both null or both non-null. If both are null, the ``Tag is assumed to apply to the whole ``Block``. They  represent offsets into the text that is spanned by that block.
+- Their ``start_idx`` and ``end_idx`` fields are either both null or both non-null. If both are null, the ``Tag is assumed to apply to the whole :py:class:`Block<steamship.data.block.Block>`. They  represent offsets into the text that is spanned by that block.
 - They are referenced via the ``blocktag`` keyword in our :ref:`query system<queries>`.
 
 Notes:

--- a/docs/nextra/plugins/developing/generators.rst
+++ b/docs/nextra/plugins/developing/generators.rst
@@ -18,7 +18,7 @@ and implement the abstract ``run`` method:
         return InvocableResponse(data=RawBlockAndTagPluginOutput(blocks=output_blocks))
 
 
-For example, an image ``Generator`` could merge the ``text`` from the input blocks and use it to generate an image ``Block``.
+For example, an image ``Generator`` could merge the ``text`` from the input blocks and use it to generate an image :py:class:`Block<steamship.data.block.Block>`.
 
 In addition to the input blocks and instance :ref:`configuration <Plugin Accepting Configuration>`, Generators can also receive
 arbitrary key/value runtime parameters.  These are present in ``request.data.options``.

--- a/docs/nextra/plugins/index.rst
+++ b/docs/nextra/plugins/index.rst
@@ -32,7 +32,7 @@ Taggers
 -------
 Taggers create :ref:`Tags` (annotations) on :ref:`Files` and :ref:`Blocks`.
 
-*Examples*: A text classifier would attach a classification ``Tag`` to a ``Block``, an image object recognizer would add ``Tags`` to a ``Block`` that identified known objects.
+*Examples*: A text classifier would attach a classification :py:class:`Tag<steamship.data.tags.tag.Tag>` to a :py:class:`Block<steamship.data.block.Block>`, an image object recognizer would add ``Tags`` to a :py:class:`Block<steamship.data.block.Block>` that identified known objects.
 
 - :ref:`Using Taggers<Taggers>`
 - :ref:`Developing Taggers<DevelopingTaggers>`

--- a/docs/nextra/plugins/using/blockifiers/using.rst
+++ b/docs/nextra/plugins/using/blockifiers/using.rst
@@ -56,7 +56,7 @@ Our currently supported blockifiers are:
 Input
 -----
 
-The input to a ``blockify`` operation is a ``File`` with no ``Blocks``.
+The input to a ``blockify`` operation is a :py:class:`File<steamship.data.file.File>` with no ``Blocks``.
 
 Output
 ------

--- a/docs/nextra/plugins/using/generators/gpt4.rst
+++ b/docs/nextra/plugins/using/generators/gpt4.rst
@@ -7,9 +7,9 @@ The GPT-4 ``Generator`` plugin uses OpenAI's GPT-4 to generate text from a text 
 or the continuation of a chat. It can also be used with GPT-3.5 by passing ``"gpt-3.5-turbo"``
 as the ``model`` configuration parameter.
 
-The plugin will treat each ``Block`` of the input as an element of a chat. If a ``Block`` has
-a ``Tag`` of kind "role" and name ( "system" | "user" | "assistant" ), the content will be passed
-to OpenAI with the corresponding role. If a ``Block`` does not have a role tag, it will
+The plugin will treat each :py:class:`Block<steamship.data.block.Block>` of the input as an element of a chat. If a :py:class:`Block<steamship.data.block.Block>` has
+a :py:class:`Tag<steamship.data.tags.tag.Tag>` of kind "role" and name ( "system" | "user" | "assistant" ), the content will be passed
+to OpenAI with the corresponding role. If a :py:class:`Block<steamship.data.block.Block>` does not have a role tag, it will
 be passed with the configured default role, which defaults to "user" (see config params below).
 
 The plugin handles retrying for rate limits and uses Steamship's OpenAI API key by default,
@@ -25,7 +25,7 @@ The simplest possible example is:
     task.wait()
     joke = task.output.blocks[0].text
 
-To build a chat interaction, you can persist the prompt components to a ``File`` object,
+To build a chat interaction, you can persist the prompt components to a :py:class:`File<steamship.data.file.File>` object,
 tagging them with their conversational roles:
 
 .. code-block:: python
@@ -51,7 +51,7 @@ tagging them with their conversational roles:
     joke = task.output.blocks[0].text
 
 In the example above, in addition to being returned as the result of the ``Task``, the output
-``Block`` is appended to ``chat_file``.
+:py:class:`Block<steamship.data.block.Block>` is appended to ``chat_file``.
 
 All output ``Blocks`` will be tagged with the "assistant" role to allow more
 content to be easily appended and generated.

--- a/docs/nextra/plugins/using/generators/index.rst
+++ b/docs/nextra/plugins/using/generators/index.rst
@@ -37,7 +37,7 @@ There are several ways to specify input to a ``Generator``:
 
    generator_task = generator.generate(text="some text")
 
-**Blocks of an existing File** You can pass the generator a ``File`` id to work on, optionally passing a subset of blocks:
+**Blocks of an existing File** You can pass the generator a :py:class:`File<steamship.data.file.File>` id to work on, optionally passing a subset of blocks:
 
 .. code-block:: python
 
@@ -78,8 +78,8 @@ The output to a ``generate`` operation is :ref:`Blocks`. You can always get thes
 
    blocks = generator_task.output.blocks
 
-By default, this output is **not** saved to a ``File``.  If you wish the result to be persisted,
-you can pass ``append_output_to_file=True`` to the call, and it will be persisted to a **new** ``File``:
+By default, this output is **not** saved to a :py:class:`File<steamship.data.file.File>`.  If you wish the result to be persisted,
+you can pass ``append_output_to_file=True`` to the call, and it will be persisted to a **new** :py:class:`File<steamship.data.file.File>`:
 
 .. code-block:: python
 
@@ -90,7 +90,7 @@ you can pass ``append_output_to_file=True`` to the call, and it will be persiste
    blocks = generator_task.output.blocks
    new_file_id = blocks[0].file_id
 
-If you want the output to be appended to an existing ``File``, just pass its id as well:
+If you want the output to be appended to an existing :py:class:`File<steamship.data.file.File>`, just pass its id as well:
 
 .. code-block:: python
 

--- a/docs/nextra/plugins/using/taggers/using.rst
+++ b/docs/nextra/plugins/using/taggers/using.rst
@@ -29,7 +29,7 @@ Note that a file must first have :ref:`Blocks`, either by direct creation or usi
 Input
 -----
 
-The input to a ``tag`` operation is a ``File``.  Most ``Taggers`` by default will tag all ``Blocks`` within that file.
+The input to a ``tag`` operation is a :py:class:`File<steamship.data.file.File>`.  Most ``Taggers`` by default will tag all ``Blocks`` within that file.
 
 Output
 ------


### PR DESCRIPTION
This is a small opportunistic PR to turn some teletype-strings into documentation links