### PR TITLE
Ignore build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ reports/
 
 # Distribution / packaging
 *.egg-info/
+build/
 
 
 # dotenv


### PR DESCRIPTION
This can be created when specifying python-client as a local dependency to another local package in requirements.txt for testing.