### PR TITLE
Add tests & slight refactor to TelegramTransport key handling

### DIFF
--- a/src/steamship/agents/examples/telegram_bot.py
+++ b/src/steamship/agents/examples/telegram_bot.py
@@ -39,7 +39,7 @@ class TelegramBot(AgentService):
     """
 
     class TelegramBotConfig(Config):
-        bot_token: str = Field(description="The secret token for your Telegram bot")
+        telegram_token: str = Field(description="The secret token for your Telegram bot")
 
     config: TelegramBotConfig
 
@@ -66,7 +66,7 @@ class TelegramBot(AgentService):
             TelegramTransport(
                 client=self.client,
                 # IMPORTANT: This is the TelegramTransportConfig, not the AgentService config!
-                config=TelegramTransportConfig(bot_token=self.config.bot_token),
+                config=TelegramTransportConfig(bot_token=self.config.telegram_token),
                 agent_service=self,
             )
         )

--- a/src/steamship/agents/examples/telegram_bot.py
+++ b/src/steamship/agents/examples/telegram_bot.py
@@ -39,7 +39,7 @@ class TelegramBot(AgentService):
     """
 
     class TelegramBotConfig(Config):
-        telegram_token: str = Field(description="The secret token for your Telegram bot")
+        telegram_bot_token: str = Field(description="The secret token for your Telegram bot")
 
     config: TelegramBotConfig
 
@@ -66,7 +66,7 @@ class TelegramBot(AgentService):
             TelegramTransport(
                 client=self.client,
                 # IMPORTANT: This is the TelegramTransportConfig, not the AgentService config!
-                config=TelegramTransportConfig(bot_token=self.config.telegram_token),
+                config=TelegramTransportConfig(bot_token=self.config.telegram_bot_token),
                 agent_service=self,
             )
         )

--- a/src/steamship/agents/mixins/transports/slack.py
+++ b/src/steamship/agents/mixins/transports/slack.py
@@ -556,7 +556,9 @@ class SlackTransport(Transport):
     @post("set_slack_access_token")
     def set_slack_access_token(self, token: str) -> InvocableResponse[str]:
         """Set the slack access token."""
-        kv = KeyValueStore(client=self.agent_service.client, store_identifier=SETTINGS_KVSTORE_KEY)
+        kv = KeyValueStore(
+            client=self.agent_service.client, store_identifier=self.setting_store_key()
+        )
         kv.set("slack_token", {"token": token})
         return InvocableResponse(string="OK")
 
@@ -564,7 +566,9 @@ class SlackTransport(Transport):
         """Return the Slack Access token, which permits the agent to post to Slack."""
         if self.bot_token:
             return self.bot_token
-        kv = KeyValueStore(client=self.agent_service.client, store_identifier=SETTINGS_KVSTORE_KEY)
+        kv = KeyValueStore(
+            client=self.agent_service.client, store_identifier=self.setting_store_key()
+        )
         v = kv.get("slack_token")
         if not v:
             return None
@@ -578,3 +582,6 @@ class SlackTransport(Transport):
         if token is None:
             return InvocableResponse(json=False)
         return InvocableResponse(json=True)
+
+    def setting_store_key(self):
+        return f"{SETTINGS_KVSTORE_KEY}-{self.agent_service.context.invocable_instance_handle}"

--- a/src/steamship/agents/mixins/transports/telegram.py
+++ b/src/steamship/agents/mixins/transports/telegram.py
@@ -42,7 +42,7 @@ class TelegramTransport(Transport):
         self.agent_service = agent_service
 
     def instance_init(self):
-        if self.bot_token:
+        if self.get_telegram_access_token():
             try:
                 self.telegram_connect_webhook()
             except Exception:  # noqa: S110
@@ -125,7 +125,7 @@ class TelegramTransport(Transport):
         ]
 
     def _get_file_url(self, file_id: str) -> str:
-        return f"https://api.telegram.org/file/bot{self.bot_token}/{self._get_file(file_id)['file_path']}"
+        return f"https://api.telegram.org/file/bot{self.get_telegram_access_token()}/{self._get_file(file_id)['file_path']}"
 
     def _download_file(self, file_id: str):
         result = requests.get(self._get_file_url(file_id))
@@ -272,7 +272,6 @@ class TelegramTransport(Transport):
     @post("is_telegram_token_set")
     def is_telegram_token_set(self) -> InvocableResponse[bool]:
         """Return whether the Telegram token has been set as a way for a remote UI to check status."""
-        token = self.get_telegram_access_token() or self.config.bot_token
-        if token is None:
+        if self.get_telegram_access_token() is None:
             return InvocableResponse(json=False)
         return InvocableResponse(json=True)

--- a/tests/assets/demo_package_spec.json
+++ b/tests/assets/demo_package_spec.json
@@ -226,6 +226,15 @@
       "doc": null
     },
     {
+      "args": [],
+      "className": "TestPackage",
+      "config": {},
+      "doc": null,
+      "path": "/resp_false",
+      "returns": "<class 'foo.InvocableResponse[dict]'>",
+      "verb": "POST"
+    },
+    {
       "returns": "<class 'foo.InvocableResponse[bytes]'>",
       "args": [],
       "className": "TestPackage",
@@ -251,6 +260,15 @@
       "path": "/resp_string",
       "verb": "GET",
       "doc": null
+    },
+    {
+      "args": [],
+      "className": "TestPackage",
+      "config": {},
+      "doc": null,
+      "path": "/resp_true",
+      "returns": "<class 'foo.InvocableResponse[dict]'>",
+      "verb": "POST"
     },
     {
       "returns": "<class 'foo.InvocableResponse[dict]'>",

--- a/tests/assets/packages/demo_package.py
+++ b/tests/assets/packages/demo_package.py
@@ -48,6 +48,14 @@ class TestPackage(PackageService):
     def resp_obj(self) -> InvocableResponse[dict]:
         return InvocableResponse(json=TestObj(name="Foo"))
 
+    @post("resp_true")
+    def resp_true(self) -> InvocableResponse[dict]:
+        return InvocableResponse(json=True)
+
+    @post("resp_false")
+    def resp_false(self) -> InvocableResponse[dict]:
+        return InvocableResponse(json=False)
+
     @get("resp_binary")
     def resp_binary(self) -> InvocableResponse[bytes]:
         _bytes = base64.b64decode(PALM_TREE_BASE_64)

--- a/tests/assets/packages/transports/test_transports_agent.py
+++ b/tests/assets/packages/transports/test_transports_agent.py
@@ -78,18 +78,18 @@ class TestTransportsAgentService(AgentService):
         # Including the web widget transport on the telegram test
         # agent to make sure it doesn't interfere
         self.add_mixin(SteamshipWidgetTransport(client=client, agent_service=self))
-        if self.config.telegram_token:
-            # Only add the mixin if a telegram key was provided.
-            self.add_mixin(
-                TelegramTransport(
-                    client=client,
-                    # TODO: We need to rename these telegram_token and telegram_api_base
-                    config=TelegramTransportConfig(
-                        bot_token=self.config.telegram_token, api_base=self.config.telegram_api_base
-                    ),
-                    agent_service=self,
-                )
+
+        # Only add the mixin if a telegram key was provided.
+        self.add_mixin(
+            TelegramTransport(
+                client=client,
+                config=TelegramTransportConfig(
+                    bot_token=self.config.telegram_token, api_base=self.config.telegram_api_base
+                ),
+                agent_service=self,
             )
+        )
+
         self.add_mixin(
             SlackTransport(
                 client=client,
@@ -97,6 +97,7 @@ class TestTransportsAgentService(AgentService):
                 agent_service=self,
             )
         )
+
         # TODO: Future Transport authors: add your transport here.
 
     @classmethod

--- a/tests/assets/packages/transports/test_transports_agent.py
+++ b/tests/assets/packages/transports/test_transports_agent.py
@@ -10,8 +10,8 @@ from steamship.invocable import Config, InvocationContext
 
 
 class TestTransportsAgentConfig(Config):
-    bot_token: Optional[str] = ""
-    api_base: Optional[str] = ""
+    telegram_token: Optional[str] = ""
+    telegram_api_base: Optional[str] = ""
     slack_api_base: Optional[str] = ""
 
 
@@ -78,14 +78,14 @@ class TestTransportsAgentService(AgentService):
         # Including the web widget transport on the telegram test
         # agent to make sure it doesn't interfere
         self.add_mixin(SteamshipWidgetTransport(client=client, agent_service=self))
-        if self.config.bot_token:
+        if self.config.telegram_token:
             # Only add the mixin if a telegram key was provided.
             self.add_mixin(
                 TelegramTransport(
                     client=client,
                     # TODO: We need to rename these telegram_token and telegram_api_base
                     config=TelegramTransportConfig(
-                        bot_token=self.config.bot_token, api_base=self.config.api_base
+                        bot_token=self.config.telegram_token, api_base=self.config.telegram_api_base
                     ),
                     agent_service=self,
                 )

--- a/tests/steamship_tests/agents/transports/test_slack.py
+++ b/tests/steamship_tests/agents/transports/test_slack.py
@@ -7,8 +7,8 @@ from steamship_tests.utils.deployables import deploy_package
 from steamship import File, Steamship
 
 config_template = {
-    "bot_token": {"type": "string"},
-    "api_base": {"type": "string"},
+    "telegram_token": {"type": "string"},
+    "telegram_api_base": {"type": "string"},
     "slack_api_base": {"type": "string"},
 }
 
@@ -24,7 +24,7 @@ def test_slack(client: Steamship):
         # This will allow us to test for the proper receipt of messages.
         instance_config = {
             "slack_api_base": mock_chat_api.invocation_url,
-            "bot_token": "",
+            "telegram_token": "",
             "api_base": "",
         }
 

--- a/tests/steamship_tests/agents/transports/test_slack.py
+++ b/tests/steamship_tests/agents/transports/test_slack.py
@@ -25,7 +25,7 @@ def test_slack(client: Steamship):
         instance_config = {
             "slack_api_base": mock_chat_api.invocation_url,
             "telegram_token": "",
-            "api_base": "",
+            "telegram_api_base": "",
         }
 
         with deploy_package(

--- a/tests/steamship_tests/agents/transports/test_telegram.py
+++ b/tests/steamship_tests/agents/transports/test_telegram.py
@@ -31,7 +31,7 @@ def test_telegram(client: Steamship):
         # invocation url.
         instance_config = {
             "telegram_token": "/",
-            "api_base": mock_chat_api.invocation_url[:-1],
+            "telegram_api_base": mock_chat_api.invocation_url[:-1],
             "slack_api_base": mock_chat_api.invocation_url,
         }
 
@@ -58,7 +58,7 @@ def test_telegram(client: Steamship):
             respond_method = "telegram_respond"
 
             # The configuration provided a token, so the token should be reported as having been set.
-            assert agent_instance.invoke("is_slack_token_set") is True
+            assert agent_instance.invoke("is_telegram_token_set") is True
 
             # Test that agent called instance_init and registered webhook
             files = File.query(client, f'kind "{MockTelegramApi.WEBHOOK_TAG}"').files
@@ -128,7 +128,7 @@ def test_telegram(client: Steamship):
             files = File.query(client, f'kind "{MockTelegramApi.WEBHOOK_TAG}"').files
             assert len(files) == 0
 
-            agent_instance.invoke("set_slack_access_token", token="foo-bar")  # noqa: S106
+            agent_instance.invoke("set_telegram_access_token", token="foo-bar")  # noqa: S106
 
             # Test that this triggered a web hook reset
             files = File.query(client, f'kind "{MockTelegramApi.WEBHOOK_TAG}"').files
@@ -140,7 +140,7 @@ def test_telegram(client: Steamship):
             # Create another instance to test LATE BOUND conections.
 
             instance_config_without_token = {
-                "api_base": mock_chat_api.invocation_url[:-1],
+                "telegram_api_base": mock_chat_api.invocation_url[:-1],
                 "slack_api_base": mock_chat_api.invocation_url,
             }
 
@@ -154,13 +154,13 @@ def test_telegram(client: Steamship):
             package_instance_2.wait_for_init()
 
             # The configuration provided a token, so the token should be reported as having been set.
-            assert package_instance_2.invoke("is_slack_token_set") is False
+            assert package_instance_2.invoke("is_telegram_token_set") is False
 
             package_instance_2.invoke(
-                "set_slack_access_token", token=instance_config.get("telegram_token")
+                "set_telegram_access_token", token=instance_config.get("telegram_token")
             )
 
-            assert package_instance_2.invoke("is_slack_token_set") is True
+            assert package_instance_2.invoke("is_telegram_token_set") is True
 
             # See that the webhook was registered
             files = File.query(client, f'kind "{MockTelegramApi.WEBHOOK_TAG}"').files

--- a/tests/steamship_tests/app/integration/test_package_instance.py
+++ b/tests/steamship_tests/app/integration/test_package_instance.py
@@ -152,6 +152,10 @@ def test_instance_invoke():
         resp_obj = instance.invoke("json_with_status", verb=Verb.POST)
         assert resp_obj == {"status": "a string"}
 
+        # Test raw true & false responses
+        assert instance.invoke("resp_true", verb=Verb.POST) is True
+        assert instance.invoke("resp_false", verb=Verb.POST) is False
+
         # Test that the __steamship_dir__ method works
         #
         # Note: The output of the InvocableResponse includes a dynamically generated value:

--- a/tests/steamship_tests/app/unit/test_demo_app_spec.py
+++ b/tests/steamship_tests/app/unit/test_demo_app_spec.py
@@ -14,7 +14,7 @@ def test_package_spec(invocable_handler: Callable[[str, str, Optional[dict]], di
 
     assert rd.get("doc") is None
     assert rd.get("methods") is not None
-    assert len(rd.get("methods")) == 23
+    assert len(rd.get("methods")) == 25
 
     saw_public = False
 


### PR DESCRIPTION
This PR:

1. Adds a few additional tests to TelegramTransport
2. Improves TelegramTransport's handling of dynamically set keys (it already had this; this PR makes it a bit more robust)

This will enable a few nice things form a user perspective:

1. Users can re-bind an Agent via the Web UI to a new Telegram Bot
2. Users can defer binding their Agent to a Telegram Bot until after they've created an instance

Follow-on work is a PR to do for Telegram what we just did for Slack in the web UI:

![image](https://github.com/steamship-core/python-client/assets/63262/1974dc4a-2171-42cf-b90b-d0e6d79de18c)
