### PR TITLE
fix: CI/CD tests sometimes fail if deployment takes longer than default Task timeout

### DIFF
--- a/src/steamship/data/package/package_version.py
+++ b/src/steamship/data/package/package_version.py
@@ -41,7 +41,6 @@ class PackageVersion(CamelModel):
         filebytes: Optional[bytes] = None,
         config_template: Optional[Dict[str, Any]] = None,
         hosting_handler: Optional[str] = None,
-        max_deployment_timeout_s: Optional[int] = None,
     ) -> PackageVersion:
 
         if filename is None and filebytes is None:
@@ -66,7 +65,7 @@ class PackageVersion(CamelModel):
             file=("package.zip", filebytes, "multipart/form-data"),
             expect=PackageVersion,
         )
-        task.wait(max_timeout_s=max_deployment_timeout_s)
+        task.wait_until_completed()
         return task.output
 
     def delete(self) -> PackageVersion:

--- a/src/steamship/data/package/package_version.py
+++ b/src/steamship/data/package/package_version.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Type
+from typing import Any, Dict, Optional, Type
 
 from pydantic import BaseModel, Field
 
@@ -35,12 +35,13 @@ class PackageVersion(CamelModel):
     @staticmethod
     def create(
         client: Client,
-        package_id: str = None,
-        handle: str = None,
-        filename: str = None,
-        filebytes: bytes = None,
-        config_template: Dict[str, Any] = None,
-        hosting_handler: str = None,
+        package_id: Optional[str] = None,
+        handle: Optional[str] = None,
+        filename: Optional[str] = None,
+        filebytes: Optional[bytes] = None,
+        config_template: Optional[Dict[str, Any]] = None,
+        hosting_handler: Optional[str] = None,
+        max_deployment_timeout_s: Optional[int] = None,
     ) -> PackageVersion:
 
         if filename is None and filebytes is None:
@@ -65,7 +66,7 @@ class PackageVersion(CamelModel):
             file=("package.zip", filebytes, "multipart/form-data"),
             expect=PackageVersion,
         )
-        task.wait()
+        task.wait(max_timeout_s=max_deployment_timeout_s)
         return task.output
 
     def delete(self) -> PackageVersion:

--- a/src/steamship/data/plugin/plugin_version.py
+++ b/src/steamship/data/plugin/plugin_version.py
@@ -56,15 +56,16 @@ class PluginVersion(CamelModel):
     def create(
         client: Client,
         handle: str,
-        plugin_id: str = None,
-        filename: str = None,
-        filebytes: bytes = None,
+        plugin_id: Optional[str] = None,
+        filename: Optional[str] = None,
+        filebytes: Optional[bytes] = None,
         hosting_memory: Optional[HostingMemory] = None,
         hosting_timeout: Optional[HostingTimeout] = None,
-        hosting_handler: str = None,
-        is_public: bool = None,
-        is_default: bool = None,
-        config_template: Dict[str, Any] = None,
+        hosting_handler: Optional[str] = None,
+        is_public: Optional[bool] = None,
+        is_default: Optional[bool] = None,
+        config_template: Optional[Dict[str, Any]] = None,
+        max_deployment_timeout_s: Optional[int] = None,
     ) -> PluginVersion:
 
         if filename is None and filebytes is None:
@@ -94,7 +95,7 @@ class PluginVersion(CamelModel):
             expect=PluginVersion,
         )
 
-        task.wait()
+        task.wait(max_timeout_s=max_deployment_timeout_s)
         return task.output
 
     @staticmethod

--- a/src/steamship/data/plugin/plugin_version.py
+++ b/src/steamship/data/plugin/plugin_version.py
@@ -65,7 +65,6 @@ class PluginVersion(CamelModel):
         is_public: Optional[bool] = None,
         is_default: Optional[bool] = None,
         config_template: Optional[Dict[str, Any]] = None,
-        max_deployment_timeout_s: Optional[int] = None,
     ) -> PluginVersion:
 
         if filename is None and filebytes is None:
@@ -95,7 +94,7 @@ class PluginVersion(CamelModel):
             expect=PluginVersion,
         )
 
-        task.wait(max_timeout_s=max_deployment_timeout_s)
+        task.wait_until_completed()
         return task.output
 
     @staticmethod

--- a/tests/steamship_tests/utils/deployables.py
+++ b/tests/steamship_tests/utils/deployables.py
@@ -83,7 +83,6 @@ def deploy_plugin(
         filebytes=zip_bytes,
         config_template=version_config_template,
         hosting_handler=hosting_handler,
-        max_deployment_timeout_s=360,  # Task default is 180; this occasionally fails in CI/CD
     )
     # TODO: This is due to having to wait for the lambda to finish deploying.
     # TODO: We should update the task system to allow its .wait() to depend on this.
@@ -132,7 +131,6 @@ def deploy_package(
         filebytes=zip_bytes,
         config_template=version_config_template,
         hosting_handler=hosting_handler,
-        max_deployment_timeout_s=360,  # Task default is 180; this occasionally fails in CI/CD
     )
 
     _wait_for_version(version)

--- a/tests/steamship_tests/utils/deployables.py
+++ b/tests/steamship_tests/utils/deployables.py
@@ -83,6 +83,7 @@ def deploy_plugin(
         filebytes=zip_bytes,
         config_template=version_config_template,
         hosting_handler=hosting_handler,
+        max_deployment_timeout_s=360,  # Task default is 180; this occasionally fails in CI/CD
     )
     # TODO: This is due to having to wait for the lambda to finish deploying.
     # TODO: We should update the task system to allow its .wait() to depend on this.
@@ -131,6 +132,7 @@ def deploy_package(
         filebytes=zip_bytes,
         config_template=version_config_template,
         hosting_handler=hosting_handler,
+        max_deployment_timeout_s=360,  # Task default is 180; this occasionally fails in CI/CD
     )
 
     _wait_for_version(version)


### PR DESCRIPTION
This PR introduces a `wait_forever` method on Task, and then uses it for Package & Plugin deployments within tests.

The hope is that some of the occasional deployment timeout failures can be avoided by simply extending the wait time.

(In response to a PR earlier today in which a single failure related to deployment timeouts happened.)