### PR TITLE
Comment out the optional field support in ConfigTemplate until it's deployed to Engine

### DIFF
--- a/src/steamship/data/manifest.py
+++ b/src/steamship/data/manifest.py
@@ -27,7 +27,7 @@ class ConfigParameterType(str, Enum):
 class ConfigParameter(BaseModel):
     type: ConfigParameterType
     description: Optional[str] = None
-    optional: Optional[bool] = None
+    # optional: Optional[bool] = None
 
     # Use strict so that Pydantic doesn't coerce values into the first one that fits
     default: Optional[Union[StrictStr, StrictBool, StrictFloat, StrictInt]] = None

--- a/src/steamship/invocable/config.py
+++ b/src/steamship/invocable/config.py
@@ -62,10 +62,12 @@ class Config(CamelModel):
             # user interface generation code has access to BOTH the status of a default value and also
             # the notion of whether the absense of a value will truly be treated as absence.
             # That way it can provide hints to the user to minimize surprise about how their inputs will be interpreted.
-            optional_ = field.required is False and field.allow_none is True
+            # optional_ = field.required is False and field.allow_none is True
 
             result[field_name] = ConfigParameter(
-                type=type_, default=default_, description=description, optional=optional_
+                type=type_,
+                default=default_,
+                description=description,  # optional=optional_
             )
 
         return result

--- a/tests/steamship_tests/app/unit/test_config_template_extraction.py
+++ b/tests/steamship_tests/app/unit/test_config_template_extraction.py
@@ -52,8 +52,8 @@ def test_config_parameter_boolean():
     assert "x" in names
     assert "y" in names
 
-    assert config_template["x"].optional is False
-    assert config_template["y"].optional is False
+    # assert config_template["x"].optional is False
+    # assert config_template["y"].optional is False
 
 
 def test_config_parameter_with_defaults():
@@ -69,16 +69,16 @@ def test_config_parameter_with_defaults():
 
     assert config_template["w"].type == ConfigParameterType.STRING
     assert config_template["w"].default == "deeeefault"
-    assert config_template["w"].optional is False
+    # assert config_template["w"].optional is False
     assert config_template["x"].type == ConfigParameterType.BOOLEAN
     assert config_template["x"].default  # Assert that the default == True
-    assert config_template["x"].optional is False
+    # assert config_template["x"].optional is False
     assert config_template["y"].type == ConfigParameterType.NUMBER
     assert config_template["y"].default == 3
-    assert config_template["y"].optional is False
+    # assert config_template["y"].optional is False
     assert config_template["z"].type == ConfigParameterType.NUMBER
     assert config_template["z"].default == 7.5
-    assert config_template["z"].optional is False
+    # assert config_template["z"].optional is False
 
 
 def test_optional_config_parameters():
@@ -102,42 +102,42 @@ def test_optional_config_parameters():
 
     assert config_template["w"].type == ConfigParameterType.STRING
     assert config_template["w"].default == "deeeefault"
-    assert config_template["w"].optional
+    # assert config_template["w"].optional
     assert config_template["x"].type == ConfigParameterType.BOOLEAN
     assert config_template["x"].default  # Assert that the default == True
-    assert config_template["x"].optional
+    # assert config_template["x"].optional
     assert config_template["y"].type == ConfigParameterType.NUMBER
     assert config_template["y"].default == 3
-    assert config_template["y"].optional
+    # assert config_template["y"].optional
     assert config_template["z"].type == ConfigParameterType.NUMBER
     assert config_template["z"].default == 7.5
-    assert config_template["z"].optional
+    # assert config_template["z"].optional
 
     assert config_template["w2"].type == ConfigParameterType.STRING
     assert config_template["w2"].default is None
-    assert config_template["w2"].optional
+    # assert config_template["w2"].optional
     assert config_template["x2"].type == ConfigParameterType.BOOLEAN
     assert config_template["x2"].default is None
-    assert config_template["x2"].optional
+    # assert config_template["x2"].optional
     assert config_template["y2"].type == ConfigParameterType.NUMBER
     assert config_template["y2"].default is None
-    assert config_template["y2"].optional
+    # assert config_template["y2"].optional
     assert config_template["z2"].type == ConfigParameterType.NUMBER
     assert config_template["z2"].default is None
-    assert config_template["z2"].optional
+    # assert config_template["z2"].optional
 
     assert config_template["w3"].type == ConfigParameterType.STRING
     assert config_template["w3"].default is None
-    assert config_template["w3"].optional
+    # assert config_template["w3"].optional
     assert config_template["x3"].type == ConfigParameterType.BOOLEAN
     assert config_template["x3"].default is None
-    assert config_template["x3"].optional
+    # assert config_template["x3"].optional
     assert config_template["y3"].type == ConfigParameterType.NUMBER
     assert config_template["y3"].default is None
-    assert config_template["y3"].optional
+    # assert config_template["y3"].optional
     assert config_template["z3"].type == ConfigParameterType.NUMBER
     assert config_template["z3"].default is None
-    assert config_template["z3"].optional
+    # assert config_template["z3"].optional
 
 
 def test_descriptions():


### PR DESCRIPTION
Reason: avoid blocking a new SDK version