### PR TITLE
feat(streaming): proof of concept for streaming agentservice execution

### DIFF
--- a/src/steamship/agents/functional/functions_based.py
+++ b/src/steamship/agents/functional/functions_based.py
@@ -1,9 +1,11 @@
+import json
 from typing import List
 
-from steamship import Block
+from steamship import Block, MimeTypes, Tag
 from steamship.agents.functional.output_parser import FunctionsBasedOutputParser
-from steamship.agents.schema import Action, AgentContext, ChatAgent, ChatLLM, Tool
-from steamship.data.tags.tag_constants import RoleTag
+from steamship.agents.schema import Action, AgentContext, ChatAgent, ChatLLM, FinishAction, Tool
+from steamship.data.tags.tag_constants import RoleTag, TagKind, TagValueKey
+from steamship.data.tags.tag_utils import get_tag
 
 
 class FunctionsBasedAgent(ChatAgent):
@@ -41,21 +43,15 @@ Only use the functions you have been provided with."""
                 .wait()
                 .to_ranked_blocks()
             )
-
             # TODO(dougreid): we need a way to threshold message inclusion, especially for small contexts
-
-            # remove the actual prompt from the semantic search (it will be an exact match)
-            messages_from_memory = [
-                msg
-                for msg in messages_from_memory
-                if msg.id != context.chat_history.last_user_message.id
-            ]
 
         # get most recent context
         messages_from_memory.extend(context.chat_history.select_messages(self.message_selector))
 
         # de-dupe the messages from memory
-        ids = []
+        ids = [
+            context.chat_history.last_user_message.id
+        ]  # filter out last user message, it is appended afterwards
         for msg in messages_from_memory:
             if msg.id not in ids:
                 messages.append(msg)
@@ -67,10 +63,8 @@ Only use the functions you have been provided with."""
         # this should happen BEFORE any agent/assistant messages related to tool selection
         messages.append(context.chat_history.last_user_message)
 
-        # get completed steps
-        actions = context.completed_steps
-        for action in actions:
-            messages.extend(action.to_chat_messages())
+        # get working history (completed actions)
+        messages.extend(self._function_calls_since_last_user_message(context))
 
         return messages
 
@@ -81,4 +75,58 @@ Only use the functions you have been provided with."""
         # Run the default LLM on those messages
         output_blocks = self.llm.chat(messages=messages, tools=self.tools)
 
-        return self.output_parser.parse(output_blocks[0].text, context)
+        future_action = self.output_parser.parse(output_blocks[0].text, context)
+        if not isinstance(future_action, FinishAction):
+            # record the LLM's function response in history
+            self._record_action_selection(future_action, context)
+        return future_action
+
+    def _function_calls_since_last_user_message(self, context: AgentContext) -> List[Block]:
+        function_calls = []
+        for block in context.chat_history.messages[::-1]:  # is this too inefficient at scale?
+            if block.chat_role == RoleTag.USER:
+                return reversed(function_calls)
+            if get_tag(block.tags, kind=TagKind.ROLE, name=RoleTag.FUNCTION):
+                function_calls.append(block)
+            elif get_tag(block.tags, kind=TagKind.FUNCTION_SELECTION):
+                function_calls.append(block)
+        return reversed(function_calls)
+
+    def _to_openai_function_selection(self, action: Action) -> str:
+        fc = {"name": action.tool}
+        args = {}
+        for block in action.input:
+            for t in block.tags:
+                if t.kind == TagKind.FUNCTION_ARG:
+                    args[t.name] = block.as_llm_input(exclude_block_wrapper=True)
+
+        fc["arguments"] = json.dumps(args)  # the arguments must be a string value NOT a dict
+        return json.dumps(fc)
+
+    def _record_action_selection(self, action: Action, context: AgentContext):
+        tags = [
+            Tag(kind=TagKind.ROLE, name=RoleTag.ASSISTANT),
+            Tag(kind=TagKind.FUNCTION_SELECTION, name=action.tool),
+        ]
+        context.chat_history.file.append_block(
+            text=self._to_openai_function_selection(action), tags=tags, mime_type=MimeTypes.TXT
+        )
+
+    def record_action_run(self, action: Action, context: AgentContext):
+        super().record_action_run(action, context)
+
+        tags = [
+            Tag(
+                kind=TagKind.ROLE,
+                name=RoleTag.FUNCTION,
+                value={TagValueKey.STRING_VALUE: action.tool},
+            ),
+        ]
+        # TODO(dougreid): I'm not convinced this is correct for tools that return multiple values.
+        #                 It _feels_ like these should be named and inlined as a single message in history, etc.
+        for block in action.output:
+            context.chat_history.file.append_block(
+                text=block.as_llm_input(exclude_block_wrapper=True),
+                tags=tags,
+                mime_type=block.mime_type,
+            )

--- a/src/steamship/agents/functional/output_parser.py
+++ b/src/steamship/agents/functional/output_parser.py
@@ -3,9 +3,9 @@ import re
 import string
 from typing import Dict, List, Optional
 
-from steamship import Block, MimeTypes, Steamship
+from steamship import Block, MimeTypes, Steamship, Tag
 from steamship.agents.schema import Action, AgentContext, FinishAction, OutputParser, Tool
-from steamship.data.tags.tag_constants import RoleTag
+from steamship.data.tags.tag_constants import RoleTag, TagKind
 from steamship.utils.utils import is_valid_uuid4
 
 
@@ -42,16 +42,45 @@ class FunctionsBasedOutputParser(OutputParser):
             try:
                 args = json.loads(arguments)
                 if text := args.get("text"):
-                    input_blocks.append(Block(text=text, mime_type=MimeTypes.TXT))
+                    input_blocks.append(
+                        Block(
+                            text=text,
+                            tags=[Tag(kind=TagKind.FUNCTION_ARG, name="text")],
+                            mime_type=MimeTypes.TXT,
+                        )
+                    )
                 elif uuid_arg := args.get("uuid"):
-                    input_blocks.append(Block.get(context.client, _id=uuid_arg))
+                    existing_block = Block.get(context.client, _id=uuid_arg)
+                    tag = Tag.create(
+                        existing_block.client,
+                        file_id=existing_block.file_id,
+                        block_id=existing_block.id,
+                        kind=TagKind.FUNCTION_ARG,
+                        name="uuid",
+                    )
+                    existing_block.tags.append(tag)
+                    input_blocks.append(existing_block)
             except json.decoder.JSONDecodeError:
                 if isinstance(arguments, str):
                     if is_valid_uuid4(arguments):
-                        input_blocks.append(Block.get(context.client, _id=uuid_arg))
+                        existing_block = Block.get(context.client, _id=arguments)
+                        tag = Tag.create(
+                            existing_block.client,
+                            file_id=existing_block.file_id,
+                            block_id=existing_block.id,
+                            kind=TagKind.FUNCTION_ARG,
+                            name="uuid",
+                        )
+                        existing_block.tags.append(tag)
+                        input_blocks.append(existing_block)
                     else:
-                        input_blocks.append(Block(text=arguments, mime_type=MimeTypes.TXT))
-
+                        input_blocks.append(
+                            Block(
+                                text=arguments,
+                                tags=[Tag(kind=TagKind.FUNCTION_ARG, name="text")],
+                                mime_type=MimeTypes.TXT,
+                            )
+                        )
         return Action(tool=tool.name, input=input_blocks, context=context)
 
     @staticmethod

--- a/src/steamship/agents/schema/action.py
+++ b/src/steamship/agents/schema/action.py
@@ -1,10 +1,9 @@
 from typing import List, Optional
 
 from pydantic import BaseModel
+from pydantic.fields import Field
 
-from steamship import Block, Tag
-from steamship.data import TagKind
-from steamship.data.tags.tag_constants import RoleTag
+from steamship import Block
 
 
 class Action(BaseModel):
@@ -22,31 +21,11 @@ class Action(BaseModel):
     output: Optional[List[Block]]
     """Any direct output produced by the Tool."""
 
-    is_final: bool = False
+    is_final: bool = Field(default=False)
     """Whether this Action should be the final action performed in a reasoning loop.
 
     Setting this to True means that the executing Agent should halt any reasoning.
     """
-
-    def to_chat_messages(self) -> List[Block]:
-        tags = [
-            Tag(kind=TagKind.ROLE, name=RoleTag.FUNCTION),
-            Tag(kind="name", name=self.tool),
-        ]
-        blocks = []
-        for block in self.output:
-            # TODO(dougreid): should we revisit as_llm_input?  we might need only the UUID...
-            blocks.append(
-                Block(
-                    text=block.as_llm_input(exclude_block_wrapper=True),
-                    tags=tags,
-                    mime_type=block.mime_type,
-                )
-            )
-
-        # TODO(dougreid): revisit when have multiple output functions.
-        # Current thinking: LLM will be OK with multiple function blocks in a row. NEEDS validation.
-        return blocks
 
 
 class FinishAction(Action):

--- a/src/steamship/agents/schema/chathistory.py
+++ b/src/steamship/agents/schema/chathistory.py
@@ -279,6 +279,28 @@ class ChatHistory:
 
         self.refresh()
 
+    def append_status_message_with_role(
+        self,
+        text: str = None,
+        role: RoleTag = RoleTag.USER,
+        tags: List[Tag] = None,
+        content: Union[str, bytes] = None,
+        url: Optional[str] = None,
+        mime_type: Optional[MimeTypes] = None,
+    ) -> Block:
+        """Append a new block to this with content provided by the end-user."""
+        tags = tags or []
+        tags.append(
+            Tag(
+                kind=TagKind.STATUS_MESSAGE,
+                name=ChatTag.ROLE,
+                value={TagValueKey.STRING_VALUE: role},
+            )
+        )
+        return self.file.append_block(
+            text=text, tags=tags, content=content, url=url, mime_type=mime_type
+        )
+
     def append_agent_message(
         self,
         text: str = None,
@@ -288,7 +310,9 @@ class ChatHistory:
         mime_type: Optional[MimeTypes] = None,
     ) -> Block:
         """Append a new block to this with status update messages from the Agent."""
-        return self.append_message_with_role(text, RoleTag.AGENT, tags, content, url, mime_type)
+        return self.append_status_message_with_role(
+            text, RoleTag.AGENT, tags, content, url, mime_type
+        )
 
     def append_tool_message(
         self,
@@ -299,7 +323,9 @@ class ChatHistory:
         mime_type: Optional[MimeTypes] = None,
     ) -> Block:
         """Append a new block to this with status update messages from the Agent."""
-        return self.append_message_with_role(text, RoleTag.TOOL, tags, content, url, mime_type)
+        return self.append_status_message_with_role(
+            text, RoleTag.TOOL, tags, content, url, mime_type
+        )
 
     def append_llm_message(
         self,
@@ -310,7 +336,9 @@ class ChatHistory:
         mime_type: Optional[MimeTypes] = None,
     ) -> Block:
         """Append a new block to this with status update messages from the Agent."""
-        return self.append_message_with_role(text, RoleTag.LLM, tags, content, url, mime_type)
+        return self.append_status_message_with_role(
+            text, RoleTag.LLM, tags, content, url, mime_type
+        )
 
 
 class ChatHistoryLoggingHandler(StreamHandler):
@@ -365,13 +393,6 @@ class ChatHistoryLoggingHandler(StreamHandler):
         if author_kind == AgentLogging.AGENT:
             return self.chat_history.append_agent_message(
                 text=message,
-                tags=[
-                    Tag(
-                        kind=TagKind.AGENT_STATUS_MESSAGE,
-                        name=message_type,
-                        value={TagValueKey.STRING_VALUE: message},
-                    ),
-                ],
                 mime_type=MimeTypes.TXT,
             )
         elif author_kind == AgentLogging.TOOL:

--- a/src/steamship/agents/service/agent_service.py
+++ b/src/steamship/agents/service/agent_service.py
@@ -2,13 +2,22 @@ import logging
 import uuid
 from typing import List, Optional
 
-from steamship import Block, SteamshipError, Task
+from pydantic.main import BaseModel
+
+from steamship import Block, File, SteamshipError, Task
 from steamship.agents.llms.openai import OpenAI
 from steamship.agents.logging import AgentLogging, StreamingOpts
 from steamship.agents.schema import Action, Agent, FinishAction
 from steamship.agents.schema.context import AgentContext, Metadata
 from steamship.agents.utils import with_llm
+from steamship.data import TagKind
+from steamship.data.tags.tag_constants import ChatTag
 from steamship.invocable import PackageService, post
+
+
+class StreamingResponse(BaseModel):
+    task: Task
+    file: File
 
 
 class AgentService(PackageService):
@@ -84,6 +93,7 @@ class AgentService(PackageService):
             },
         )
 
+        # save action selection to history...
         return action
 
     def run_action(self, agent: Agent, action: Action, context: AgentContext):
@@ -109,7 +119,7 @@ class AgentService(PackageService):
                     },
                 )
                 action.output = output_blocks
-                context.completed_steps.append(action)
+                agent.record_action_run(action, context)
                 return
 
         tool = next((tool for tool in agent.tools if tool.name == action.tool), None)
@@ -150,7 +160,8 @@ class AgentService(PackageService):
             action.is_final = (
                 tool.is_final
             )  # Permit the tool to decide if this action should halt the reasoning loop.
-            context.completed_steps.append(action)
+
+            agent.record_action_run(action, context)
             if context.action_cache and tool.cacheable:
                 context.action_cache.update(key=action, value=action.output)
 
@@ -294,6 +305,33 @@ class AgentService(PackageService):
 
         context = with_llm(context=context, llm=llm)
         return context
+
+    @post("async_prompt")
+    def async_prompt(
+        self, prompt: Optional[str] = None, context_id: Optional[str] = None, **kwargs
+    ) -> StreamingResponse:
+        with self.build_default_context(context_id, **kwargs) as context:
+            ctx_id = context_id
+
+            # if no context ID is provided, we need to make sure that the streaming context ID
+            # is the same one as the non-streaming.
+            if not ctx_id:
+                ctx_file = context.chat_history.file
+                for tag in ctx_file.tags:
+                    if tag.kind == TagKind.CHAT and tag.name == ChatTag.CONTEXT_KEYS:
+                        if value := tag.value:
+                            ctx_id = value.get("id", None)
+
+            # if you can't find a consistent context_id, then there is no way to provide an accurate
+            # streaming endpoint.
+            if not ctx_id:
+                # TODO(dougreid): this points to a slight flaw in the context_keys vs. context_id
+                raise SteamshipError("Error setting up context: no id found for context.")
+
+            task = self.invoke_later(
+                "/prompt", arguments={"prompt": prompt, "context_id": ctx_id, **kwargs}
+            )
+            return StreamingResponse(task=task, file=context.chat_history.file)
 
     @post("prompt")
     def prompt(

--- a/src/steamship/data/tags/tag_constants.py
+++ b/src/steamship/data/tags/tag_constants.py
@@ -30,9 +30,12 @@ class TagKind(str, Enum):
     CHAT = "chat"
     CHAT_HISTORY_CONTEXT = "chat-history-context"
     MESSAGE_ID = "message-id"
+    STATUS_MESSAGE = "status-message"
     AGENT_STATUS_MESSAGE = "agent-status-message"
     TOOL_STATUS_MESSAGE = "tool-status-message"
     LLM_STATUS_MESSAGE = "llm-status-message"
+    FUNCTION_ARG = "function-arg"
+    FUNCTION_SELECTION = "function-selection"
 
 
 class DocTag(str, Enum):

--- a/src/steamship/utils/repl.py
+++ b/src/steamship/utils/repl.py
@@ -14,6 +14,8 @@ from steamship import Block, Steamship, Task, TaskState
 from steamship.agents.logging import AgentLogging
 from steamship.agents.schema import AgentContext, Tool
 from steamship.agents.service.agent_service import AgentService
+from steamship.data import TagKind, TagValueKey
+from steamship.data.tags.tag_utils import get_tag
 from steamship.data.workspace import Workspace
 from steamship.invocable.dev_logging_handler import DevelopmentLoggingHandler
 
@@ -202,10 +204,23 @@ class AgentREPL(SteamshipREPL):
         history = agent_ctx.chat_history
         history.refresh()
         for block in history.messages:
-            if block.is_text():
-                print(f"[{block.chat_role}] {block.text}")
+            chat_role = block.chat_role
+            status_msg = get_tag(block.tags, kind=TagKind.STATUS_MESSAGE)
+            if not chat_role and not status_msg:
+                continue
+
+            if chat_role:
+                prefix = f"[{chat_role}]"
             else:
-                print(f"[{block.chat_role}] {block.id} ({block.mime_type})")
+                if value := status_msg.value:
+                    prefix = f"[{value.get(TagValueKey.STRING_VALUE)} status]"
+                else:
+                    prefix = "[status]"
+
+            if block.is_text():
+                print(f"{prefix} {block.text}")
+            else:
+                print(f"{prefix} {block.id} ({block.mime_type})")
         print("\n------------------------------\n")
         exit(0)
 


### PR DESCRIPTION
This PR presents a series of changes that should support a way to stream response information back to a client via an AgentService.

In order to achieve the streaming result, a new method on the AgentService is exposed: `async_prompt`. This new method returns a new `StreamingResponse` that has two fields: `task` and `file`. These fields provide access to (a) the async task that will be streaming results and (b) a file (here the `ChatHistory` file) to which all status messages and assistant interactions will be saved.

This PR relies on a full deployment of https://github.com/steamship-plugins/gpt4/pull/10 to the target environment for testing / validation.