### PR TITLE
feat(tasks): expose request ID field on Tasks

### DIFF
--- a/src/steamship/base/tasks.py
+++ b/src/steamship/base/tasks.py
@@ -142,6 +142,9 @@ class Task(GenericCamelModel, Generic[T]):
     task_id: str = None  # The id of this task
     user_id: str = None  # The user who requested this task
     workspace_id: str = None  # The workspace in which this task is executing
+    request_id: Optional[str] = Field(
+        default=None
+    )  # The ID for the request that lead to the creation of this Task.
 
     # Note: The Field object prevents this from being serialized into JSON (and causing a crash)
     expect: Type = Field(

--- a/tests/steamship_tests/base/test_task.py
+++ b/tests/steamship_tests/base/test_task.py
@@ -26,6 +26,7 @@ def test_background_task_call():
     # When we background it, we get a task back instead
     result_2_task = client.post("task/noop", expect=NoOpResult, as_background_task=True)
     assert result_2_task is not None
+    assert result_2_task.request_id is not None
     assert result_2_task.state == TaskState.waiting
 
     result_2_task.wait()
@@ -52,6 +53,7 @@ def test_task_wait_milliseconds():
     # When we background it, we get a task back instead
     result_2_task = client.post("task/noop", expect=NoOpResult, task_delay_ms=1000)
     assert result_2_task is not None
+    assert result_2_task.request_id is not None
     assert result_2_task.state == TaskState.waiting
 
     result_2_task.wait()
@@ -68,6 +70,7 @@ def test_task_update():
     # We'll background this operation in order to transform it into a task we can manipulate
     result_task = client.post("task/noop", expect=NoOpResult, as_background_task=True)
     assert result_task is not None
+    assert result_task.request_id is not None
     assert result_task.state == TaskState.waiting
 
     result_task.wait()


### PR DESCRIPTION
This PR is part of the work to enable streaming use cases for the Agent SDK. With this change, it will be possible to extract the request ID from a `Task` obj. This request ID can then be used, in concert with a `File`, to stream updates (blocks added).