### PR TITLE
feat(streaming): initial implementation of streaming agentservice execution

### DIFF
--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         environment: [Production, Staging]
-        python-version: [ "3.8" ]
+        python-version: [ "3.10" ]
         include:
           - environment: Production
             api-key: STEAMSHIP_PROD_TEST_KEY
@@ -35,10 +35,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
 
       - name: Install Virtualenv
         run: python3 -m venv .venv

--- a/.github/workflows/test-staging.yml
+++ b/.github/workflows/test-staging.yml
@@ -18,16 +18,16 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: [ "3.8" ]
+        python-version: [ "3.10" ]
       fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
 
       - name: Install Virtualenv
         run: python3 -m venv .venv

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -51,6 +51,7 @@ sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
+sseclient-py==1.8.0
 toml==0.10.2
 tomli==2.0.0
 typing-extensions==4.2.0

--- a/src/steamship/agents/functional/functions_based.py
+++ b/src/steamship/agents/functional/functions_based.py
@@ -5,9 +5,7 @@ from typing import List
 from steamship import Block, MimeTypes, Tag
 from steamship.agents.functional.output_parser import FunctionsBasedOutputParser
 from steamship.agents.schema import Action, AgentContext, ChatAgent, ChatLLM, FinishAction, Tool
-
 from steamship.data.tags.tag_constants import ChatTag, RoleTag, TagKind, TagValueKey
-from steamship.data.tags.tag_constants import RoleTag, TagKind, TagValueKey
 from steamship.data.tags.tag_utils import get_tag
 
 

--- a/src/steamship/agents/functional/functions_based.py
+++ b/src/steamship/agents/functional/functions_based.py
@@ -5,7 +5,9 @@ from typing import List
 from steamship import Block, MimeTypes, Tag
 from steamship.agents.functional.output_parser import FunctionsBasedOutputParser
 from steamship.agents.schema import Action, AgentContext, ChatAgent, ChatLLM, FinishAction, Tool
+
 from steamship.data.tags.tag_constants import ChatTag, RoleTag, TagKind, TagValueKey
+from steamship.data.tags.tag_constants import RoleTag, TagKind, TagValueKey
 from steamship.data.tags.tag_utils import get_tag
 
 
@@ -44,15 +46,7 @@ Only use the functions you have been provided with."""
                 .wait()
                 .to_ranked_blocks()
             )
-
             # TODO(dougreid): we need a way to threshold message inclusion, especially for small contexts
-
-            # remove the actual prompt from the semantic search (it will be an exact match)
-            messages_from_memory = [
-                msg
-                for msg in messages_from_memory
-                if msg.id != context.chat_history.last_user_message.id
-            ]
 
         # get most recent context
         messages_from_memory.extend(context.chat_history.select_messages(self.message_selector))

--- a/src/steamship/agents/functional/functions_based.py
+++ b/src/steamship/agents/functional/functions_based.py
@@ -30,13 +30,17 @@ Only use the functions you have been provided with."""
             output_parser=FunctionsBasedOutputParser(tools=tools), llm=llm, tools=tools, **kwargs
         )
 
+    def _get_or_create_system_message(self, context: AgentContext) -> Block:
+        sys_msg = context.chat_history.last_system_message
+        if sys_msg:
+            return sys_msg
+
+        return context.chat_history.append_system_message(text=self.PROMPT, mime_type=MimeTypes.TXT)
+
     def build_chat_history_for_tool(self, context: AgentContext) -> List[Block]:
-        messages: List[Block] = []
+        messages: List[Block] = [self._get_or_create_system_message(context)]
 
         # get system message
-        system_message = Block(text=self.PROMPT)
-        system_message.set_chat_role(RoleTag.SYSTEM)
-        messages.append(system_message)
 
         messages_from_memory = []
         # get prior conversations
@@ -115,6 +119,11 @@ Only use the functions you have been provided with."""
                 value={TagValueKey.STRING_VALUE: RoleTag.ASSISTANT},
             ),
             Tag(kind=TagKind.FUNCTION_SELECTION, name=action.tool),
+            Tag(
+                kind="request-id",
+                name=context.request_id,
+                value={TagValueKey.STRING_VALUE: context.request_id},
+            ),
         ]
         context.chat_history.file.append_block(
             text=self._to_openai_function_selection(action), tags=tags, mime_type=MimeTypes.TXT
@@ -136,6 +145,11 @@ Only use the functions you have been provided with."""
             Tag(
                 kind="name",
                 name=action.tool,
+            ),
+            Tag(
+                kind="request-id",
+                name=context.request_id,
+                value={TagValueKey.STRING_VALUE: context.request_id},
             ),
         ]
         # TODO(dougreid): I'm not convinced this is correct for tools that return multiple values.

--- a/src/steamship/agents/functional/functions_based.py
+++ b/src/steamship/agents/functional/functions_based.py
@@ -38,7 +38,8 @@ Only use the functions you have been provided with."""
         return context.chat_history.append_system_message(text=self.PROMPT, mime_type=MimeTypes.TXT)
 
     def build_chat_history_for_tool(self, context: AgentContext) -> List[Block]:
-        messages: List[Block] = [self._get_or_create_system_message(context)]
+        sys_msg = self._get_or_create_system_message(context)
+        messages: List[Block] = [sys_msg]
 
         # get system message
 
@@ -58,7 +59,10 @@ Only use the functions you have been provided with."""
         messages_from_memory.sort(key=attrgetter("index_in_file"))
 
         # de-dupe the messages from memory
-        ids = [context.chat_history.last_user_message.id]
+        ids = [
+            sys_msg.id,
+            context.chat_history.last_user_message.id,
+        ]  # filter out last user message, it is appended afterwards
         for msg in messages_from_memory:
             if msg.id not in ids:
                 messages.append(msg)

--- a/src/steamship/agents/functional/output_parser.py
+++ b/src/steamship/agents/functional/output_parser.py
@@ -141,4 +141,5 @@ class FunctionsBasedOutputParser(OutputParser):
         finish_blocks = FunctionsBasedOutputParser._blocks_from_text(context.client, text)
         for finish_block in finish_blocks:
             finish_block.set_chat_role(RoleTag.ASSISTANT)
+            finish_block.set_request_id(context.request_id)
         return FinishAction(output=finish_blocks, context=context)

--- a/src/steamship/agents/llms/openai.py
+++ b/src/steamship/agents/llms/openai.py
@@ -58,6 +58,7 @@ class OpenAI(LLM):
         if "max_tokens" in kwargs:
             options["max_tokens"] = kwargs["max_tokens"]
 
+        # TODO(dougreid): do we care about streaming here? should we take a kwarg that is file_id ?
         action_task = self.generator.generate(text=prompt, options=options)
         action_task.wait()
         return action_task.output.blocks
@@ -84,47 +85,74 @@ class ChatOpenAI(ChatLLM, OpenAI):
         Supported kwargs include:
         - `max_tokens` (controls the size of LLM responses)
         """
+        if len(messages) <= 0:
+            return []
 
-        temp_file = File.create(
-            client=self.client,
-            blocks=messages,
-            tags=[Tag(kind=TagKind.GENERATION, name=GenerationTag.PROMPT_COMPLETION)],
-        )
+        options = {}
+        if len(tools) > 0:
+            functions = []
+            for tool in tools:
+                functions.append(tool.as_openai_function().dict())
+            options["functions"] = functions
 
-        try:
-            options = {}
-            if len(tools) > 0:
-                functions = []
-                for tool in tools:
-                    functions.append(tool.as_openai_function().dict())
-                options["functions"] = functions
+        if "max_tokens" in kwargs:
+            options["max_tokens"] = kwargs["max_tokens"]
 
-            if "max_tokens" in kwargs:
-                options["max_tokens"] = kwargs["max_tokens"]
+        extra = {
+            AgentLogging.LLM_NAME: "OpenAI",
+            AgentLogging.IS_MESSAGE: True,
+            AgentLogging.MESSAGE_TYPE: AgentLogging.PROMPT,
+            AgentLogging.MESSAGE_AUTHOR: AgentLogging.LLM,
+        }
 
-            extra = {
-                AgentLogging.LLM_NAME: "OpenAI",
-                AgentLogging.IS_MESSAGE: True,
-                AgentLogging.MESSAGE_TYPE: AgentLogging.PROMPT,
-                AgentLogging.MESSAGE_AUTHOR: AgentLogging.LLM,
-            }
-
-            if logging.DEBUG >= logging.root.getEffectiveLevel():
-                extra["messages"] = json.dumps(
-                    "\n".join([f"[{msg.chat_role}] {msg.as_llm_input()}" for msg in messages])
-                )
-                extra["tools"] = ",".join([t.name for t in tools])
-            else:
-                extra["num_messages"] = len(messages)
-                extra["num_tools"] = len(tools)
-
-            logging.info(f"OpenAI ChatComplete ({messages[-1].as_llm_input()})", extra=extra)
-
-            tool_selection_task = self.generator.generate(
-                input_file_id=temp_file.id, options=options
+        if logging.DEBUG >= logging.root.getEffectiveLevel():
+            extra["messages"] = json.dumps(
+                "\n".join([f"[{msg.chat_role}] {msg.as_llm_input()}" for msg in messages])
             )
-            tool_selection_task.wait()
+            extra["tools"] = ",".join([t.name for t in tools])
+        else:
+            extra["num_messages"] = len(messages)
+            extra["num_tools"] = len(tools)
 
-            return tool_selection_task.output.blocks
-        finally:
-            temp_file.delete()
+        logging.info(f"OpenAI ChatComplete ({messages[-1].as_llm_input()})", extra=extra)
+
+        # for streaming use cases, we want to always use the existing file
+        # the way to detect this would be if all messages were from the same file
+        if self._from_same_existing_file(blocks=messages):
+            file_id = messages[0].file_id
+            block_indices = [b.index_in_file for b in messages]
+            generate_task = self.generator.generate(
+                input_file_id=file_id,
+                input_file_block_index_list=block_indices.sort(),
+                options=options,
+                append_output_to_file=True,
+            )
+        else:
+            tags = [Tag(kind=TagKind.GENERATION, name=GenerationTag.PROMPT_COMPLETION)]
+            try:
+                temp_file = File.create(client=self.client, blocks=messages, tags=tags)
+                generate_task = self.generator.generate(input_file_id=temp_file.id, options=options)
+            finally:
+                temp_file.delete()
+
+        generate_task.wait()
+
+        return generate_task.output.blocks
+
+    def _from_same_existing_file(self, blocks: List[Block]) -> bool:
+        if len(blocks) == 1:
+            return blocks[0].file_id is not None
+        file_id = blocks[0].file_id
+        for b in blocks[1:]:
+            if b.file_id != file_id:
+                return False
+        return True
+
+    def _from_same_file(self, blocks: List[Block]) -> bool:
+        if len(blocks) <= 1:
+            return True
+        file_id = blocks[0].file_id
+        for b in blocks[1:]:
+            if b.file_id != file_id:
+                return False
+        return True

--- a/src/steamship/agents/llms/openai.py
+++ b/src/steamship/agents/llms/openai.py
@@ -105,7 +105,7 @@ class ChatOpenAI(ChatLLM, OpenAI):
             AgentLogging.MESSAGE_AUTHOR: AgentLogging.LLM,
         }
 
-        if logging.DEBUG >= logging.root.getEffectiveLevel():
+        if logging.WARNING >= logging.root.getEffectiveLevel():
             extra["messages"] = json.dumps(
                 "\n".join([f"[{msg.chat_role}] {msg.as_llm_input()}" for msg in messages])
             )
@@ -121,9 +121,11 @@ class ChatOpenAI(ChatLLM, OpenAI):
         if self._from_same_existing_file(blocks=messages):
             file_id = messages[0].file_id
             block_indices = [b.index_in_file for b in messages]
+            block_indices.sort()
+            logging.info(f"OpenAI ChatComplete block_indices [{block_indices}]")
             generate_task = self.generator.generate(
                 input_file_id=file_id,
-                input_file_block_index_list=block_indices.sort(),
+                input_file_block_index_list=block_indices,
                 options=options,
                 append_output_to_file=True,
             )

--- a/src/steamship/agents/llms/openai.py
+++ b/src/steamship/agents/llms/openai.py
@@ -147,12 +147,3 @@ class ChatOpenAI(ChatLLM, OpenAI):
             if b.file_id != file_id:
                 return False
         return True
-
-    def _from_same_file(self, blocks: List[Block]) -> bool:
-        if len(blocks) <= 1:
-            return True
-        file_id = blocks[0].file_id
-        for b in blocks[1:]:
-            if b.file_id != file_id:
-                return False
-        return True

--- a/src/steamship/agents/logging.py
+++ b/src/steamship/agents/logging.py
@@ -69,6 +69,9 @@ class StreamingOpts(BaseModel):
 
     Agent messages are any logging messages with: `AgentLogging.MESSAGE_AUTHOR == AgentLogging.AGENT`. These typically
     are status messages logged in either the `AgentService` or the `Agent` code.
+
+    NOTE: Agent status messages include "request complete" signal messages for streaming use cases. Disabling
+    these messages will impact streaming generator function.
     """
 
     include_llm_messages: bool = Field(default=True)

--- a/src/steamship/agents/schema/action.py
+++ b/src/steamship/agents/schema/action.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from pydantic import BaseModel
+from pydantic.fields import Field
 
 from steamship import Block
 
@@ -20,41 +21,11 @@ class Action(BaseModel):
     output: Optional[List[Block]]
     """Any direct output produced by the Tool."""
 
-    is_final: bool = False
+    is_final: bool = Field(default=False)
     """Whether this Action should be the final action performed in a reasoning loop.
 
     Setting this to True means that the executing Agent should halt any reasoning.
     """
-
-    # def to_chat_messages(self) -> List[Block]:
-    #     blocks = []
-    #     for arg in self.input:
-    #
-    #
-    #     blocks.append(
-    #         Block(
-    #             text=json.dumps({"name": f"{self.tool}", "arguments": "{ \"text\": \"who is the current president of Taiwan?\" }"}),
-    #         )
-    #     )
-    #
-    #     tags = [
-    #         Tag(kind=TagKind.ROLE, name=RoleTag.FUNCTION),
-    #         Tag(kind="name", name=self.tool),
-    #     ]
-    #
-    #     for block in self.output:
-    #         # TODO(dougreid): should we revisit as_llm_input?  we might need only the UUID...
-    #         blocks.append(
-    #             Block(
-    #                 text=block.as_llm_input(exclude_block_wrapper=True),
-    #                 tags=tags,
-    #                 mime_type=block.mime_type,
-    #             )
-    #         )
-    #
-    #     # TODO(dougreid): revisit when have multiple output functions.
-    #     # Current thinking: LLM will be OK with multiple function blocks in a row. NEEDS validation.
-    #     return blocks
 
 
 class FinishAction(Action):

--- a/src/steamship/agents/schema/agent.py
+++ b/src/steamship/agents/schema/agent.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel
 from pydantic.fields import Field
@@ -27,6 +27,14 @@ class Agent(BaseModel, ABC):
 
     message_selector: MessageSelector = Field(default=NoMessages())
     """Selector of messages from ChatHistory. Used for conversation memory retrieval."""
+
+    def default_system_message(self) -> Optional[str]:
+        """The default system message used by Agents to drive LLM instruction.
+
+        Non Chat-based Agents should always return None. Chat-based Agents should override
+        this method to provide a default prompt.
+        """
+        return None
 
     @abstractmethod
     def next_action(self, context: AgentContext) -> Action:

--- a/src/steamship/agents/schema/agent.py
+++ b/src/steamship/agents/schema/agent.py
@@ -11,7 +11,8 @@ from steamship.agents.schema.llm import LLM, ChatLLM
 from steamship.agents.schema.message_selectors import MessageSelector, NoMessages
 from steamship.agents.schema.output_parser import OutputParser
 from steamship.agents.schema.tool import Tool
-from steamship.data.tags.tag_constants import RoleTag
+from steamship.data.tags.tag_constants import RoleTag, TagKind
+from steamship.data.tags.tag_utils import get_tag
 
 
 class Agent(BaseModel, ABC):
@@ -57,17 +58,16 @@ class LLMAgent(Agent):
             # Internal Status Messages are not considered part of **prompt** history.
             # Their inclusion could lead to problematic LLM behavior, etc.
             # As such are explicitly skipped here:
-            # - DON'T RETURN AGENT MESSAGES
-            # - DON'T RETURN TOOL MESSAGES
-            # - DON'T RETURN LLM MESSAGES
+            # - DON'T RETURN STATUS MESSAGES
+            # - DON'T RETURN FUNCTION or FUNCTION_SELECTION MESSAGES
             if role == RoleTag.USER:
                 as_strings.append(f"User: {block.text}")
-            elif role == RoleTag.ASSISTANT:
+            elif role == RoleTag.ASSISTANT and (
+                get_tag(block.tags, TagKind.FUNCTION_SELECTION) is None
+            ):
                 as_strings.append(f"Assistant: {block.text}")
             elif role == RoleTag.SYSTEM:
                 as_strings.append(f"System: {block.text}")
-            elif role == RoleTag.FUNCTION:
-                as_strings.append(f"Function: {block.text}")
         return "\n".join(as_strings)
 
 

--- a/src/steamship/agents/schema/chathistory.py
+++ b/src/steamship/agents/schema/chathistory.py
@@ -285,6 +285,28 @@ class ChatHistory:
 
         self.refresh()
 
+    def append_status_message_with_role(
+        self,
+        text: str = None,
+        role: RoleTag = RoleTag.USER,
+        tags: List[Tag] = None,
+        content: Union[str, bytes] = None,
+        url: Optional[str] = None,
+        mime_type: Optional[MimeTypes] = None,
+    ) -> Block:
+        """Append a new block to this with content provided by the end-user."""
+        tags = tags or []
+        tags.append(
+            Tag(
+                kind=TagKind.STATUS_MESSAGE,
+                name=ChatTag.ROLE,
+                value={TagValueKey.STRING_VALUE: role},
+            )
+        )
+        return self.file.append_block(
+            text=text, tags=tags, content=content, url=url, mime_type=mime_type
+        )
+
     def append_agent_message(
         self,
         text: str = None,
@@ -294,7 +316,9 @@ class ChatHistory:
         mime_type: Optional[MimeTypes] = None,
     ) -> Block:
         """Append a new block to this with status update messages from the Agent."""
-        return self.append_message_with_role(text, RoleTag.AGENT, tags, content, url, mime_type)
+        return self.append_status_message_with_role(
+            text, RoleTag.AGENT, tags, content, url, mime_type
+        )
 
     def append_tool_message(
         self,
@@ -305,7 +329,9 @@ class ChatHistory:
         mime_type: Optional[MimeTypes] = None,
     ) -> Block:
         """Append a new block to this with status update messages from the Agent."""
-        return self.append_message_with_role(text, RoleTag.TOOL, tags, content, url, mime_type)
+        return self.append_status_message_with_role(
+            text, RoleTag.TOOL, tags, content, url, mime_type
+        )
 
     def append_llm_message(
         self,
@@ -316,7 +342,9 @@ class ChatHistory:
         mime_type: Optional[MimeTypes] = None,
     ) -> Block:
         """Append a new block to this with status update messages from the Agent."""
-        return self.append_message_with_role(text, RoleTag.LLM, tags, content, url, mime_type)
+        return self.append_status_message_with_role(
+            text, RoleTag.LLM, tags, content, url, mime_type
+        )
 
 
 class ChatHistoryLoggingHandler(StreamHandler):
@@ -371,13 +399,6 @@ class ChatHistoryLoggingHandler(StreamHandler):
         if author_kind == AgentLogging.AGENT:
             return self.chat_history.append_agent_message(
                 text=message,
-                tags=[
-                    Tag(
-                        kind=TagKind.AGENT_STATUS_MESSAGE,
-                        name=message_type,
-                        value={TagValueKey.STRING_VALUE: message},
-                    ),
-                ],
                 mime_type=MimeTypes.TXT,
             )
         elif author_kind == AgentLogging.TOOL:

--- a/src/steamship/agents/schema/chathistory.py
+++ b/src/steamship/agents/schema/chathistory.py
@@ -346,6 +346,23 @@ class ChatHistory:
             text, RoleTag.LLM, tags, content, url, mime_type
         )
 
+    def append_request_complete_message(
+        self,
+        request_id: str,
+    ) -> Block:
+        """Append a new block to this with status update messages from the Agent."""
+
+        tags = [
+            Tag(kind=TagKind.AGENT_STATUS_MESSAGE, name=ChatTag.REQUEST_COMPLETE),
+            Tag(
+                kind="request-id",
+                name=request_id,
+                value={TagValueKey.STRING_VALUE: request_id},
+            ),
+        ]
+
+        return self.append_status_message_with_role("", RoleTag.AGENT, tags, None, None, None)
+
 
 class ChatHistoryLoggingHandler(StreamHandler):
     """Logs messages emitted by Agents and Tools into a ChatHistory file.

--- a/src/steamship/agents/schema/context.py
+++ b/src/steamship/agents/schema/context.py
@@ -119,3 +119,8 @@ class AgentContext:
             logger = logging.getLogger()
             logger.removeHandler(self._chat_history_logger)
             self._chat_history_logger = None
+
+        # Here we append a final request complete block, which will have no text, but hold a special tag
+        # NOTE: This **MUST** happen as the absolute last thing in the AgentService run. If chat history
+        # is updated **outside** of `run_agent`, then this will signal a request completion **before** it happens.
+        self.chat_history.append_request_complete_message(self.request_id)

--- a/src/steamship/agents/schema/context.py
+++ b/src/steamship/agents/schema/context.py
@@ -75,7 +75,23 @@ class AgentContext:
         use_action_cache: Optional[bool] = False,
         streaming_opts: Optional[StreamingOpts] = None,
         request_id: Optional[str] = None,
+        initial_system_message: Optional[str] = None,
     ):
+        """Get the AgentContext that corresponds to the parameters supplied.
+
+        If the AgentContext does not already exist, a new one will be created and returned.
+
+        Args:
+            client(Steamship): Steamship workspace-scoped client
+            context_keys(dict): key-value pairs used to uniquely identify a context within a workspace
+            tags(list): List of Steamship Tags to attach to a ChatHistory for a new context
+            searchable(bool): Whether the ContextHistory should embed appended messages for subsequent retrieval
+            use_llm_cache(bool): Determines if an LLM Cache should be created for a new context
+            use_action_cache(bool): Determines if an Action Cache should be created for a new context
+            streaming_opts(StreamingOpts): Determines how status messages are appended to the context's ChatHistory
+            request_id(str): Provides request-scoping for the context's ChatHistory messages
+            initial_system_message(str): System message used to initialize the context's ChatHistory. If one already exists, this will be ignored.
+        """
         from steamship.agents.schema.chathistory import ChatHistory
 
         if streaming_opts is None:
@@ -88,6 +104,10 @@ class AgentContext:
         context = AgentContext(streaming_opts=streaming_opts, request_id=request_id)
         context.chat_history = history
         context.client = client
+
+        if initial_system_message and not context.chat_history.last_system_message:
+            # ensure the system message is the first in the history
+            context.chat_history.append_system_message(text=initial_system_message)
 
         if use_action_cache:
             context.action_cache = ActionCache.get_or_create(

--- a/src/steamship/agents/schema/context.py
+++ b/src/steamship/agents/schema/context.py
@@ -53,11 +53,13 @@ class AgentContext:
     request_id: str
     """Identifier for the current request being handled by this context."""
 
-    def __init__(self, request_id: str, streaming_opts: Optional[StreamingOpts] = None):
+    def __init__(
+        self, request_id: Optional[str] = None, streaming_opts: Optional[StreamingOpts] = None
+    ):
         self.metadata = {}
         self.completed_steps = []
         self.emit_funcs = []
-        self.request_id = request_id  # TODO: protect this?
+        self.request_id = request_id or str(uuid.uuid4())  # TODO: protect this?
         if streaming_opts is not None:
             self._streaming_opts = streaming_opts
         else:

--- a/src/steamship/agents/schema/context.py
+++ b/src/steamship/agents/schema/context.py
@@ -123,4 +123,5 @@ class AgentContext:
         # Here we append a final request complete block, which will have no text, but hold a special tag
         # NOTE: This **MUST** happen as the absolute last thing in the AgentService run. If chat history
         # is updated **outside** of `run_agent`, then this will signal a request completion **before** it happens.
-        self.chat_history.append_request_complete_message(self.request_id)
+        if self._streaming_opts.include_agent_messages:
+            self.chat_history.append_request_complete_message(self.request_id)

--- a/src/steamship/agents/schema/message_selectors.py
+++ b/src/steamship/agents/schema/message_selectors.py
@@ -40,6 +40,11 @@ def is_tool_function_message(block: Block) -> bool:
     return is_function_call
 
 
+def is_assistant_function_message(block: Block) -> bool:
+    is_function_selection = get_tag(block.tags, kind=TagKind.FUNCTION_SELECTION)
+    return is_assistant_message(block) and is_function_selection
+
+
 def is_user_history_message(block: Block) -> bool:
     return is_user_message(block) or (
         is_assistant_message(block) and not is_function_message(block)
@@ -51,7 +56,6 @@ class MessageWindowMessageSelector(MessageSelector):
 
     def get_messages(self, messages: List[Block]) -> List[Block]:
         msgs = messages[:]
-        # msgs.pop()
         have_seen_user_message = False
         if is_user_message(msgs[-1]):
             have_seen_user_message = True

--- a/src/steamship/agents/service/agent_service.py
+++ b/src/steamship/agents/service/agent_service.py
@@ -274,6 +274,9 @@ class AgentService(PackageService):
             logging.info(f"Emitting via function '{func.__name__}' for context: {context.id}")
             func(action.output, context.metadata)
 
+        # Here we append a final request complete block, which will have no text, but hold a special tag
+        context.chat_history.append_request_complete_message(self.client.config.request_id)
+
     def set_default_agent(self, agent: Agent):
         self.agent = agent
 

--- a/src/steamship/agents/service/agent_service.py
+++ b/src/steamship/agents/service/agent_service.py
@@ -301,7 +301,7 @@ class AgentService(PackageService):
                 return None
 
     def build_default_context(self, context_id: Optional[str] = None, **kwargs) -> AgentContext:
-        """Build's the agent's default context.
+        """Build the agent's default context.
 
         The provides a single place to implement (or override) the default context that will be used by endpoints
         that transports define. This allows an Agent developer to use, eg, the TelegramTransport but with a custom
@@ -342,6 +342,7 @@ class AgentService(PackageService):
                 include_llm_messages=include_llm_messages,
                 include_tool_messages=include_tool_messages,
             ),
+            initial_system_message=self.get_default_agent().default_system_message(),
         )
 
         # Add a default LLM to the context, using the Agent's if it exists.
@@ -361,7 +362,11 @@ class AgentService(PackageService):
         if context_id is None:
             context_id = uuid.uuid4()
 
-        ctx = AgentContext.get_or_create(self.client, context_keys={"id": f"{context_id}"})
+        ctx = AgentContext.get_or_create(
+            self.client,
+            context_keys={"id": f"{context_id}"},
+            initial_system_message=self.get_default_agent().default_system_message(),
+        )
         return ctx.chat_history.file
 
     def _streaming_context_id_and_file(

--- a/src/steamship/agents/service/agent_service.py
+++ b/src/steamship/agents/service/agent_service.py
@@ -327,6 +327,7 @@ class AgentService(PackageService):
 
         context = AgentContext.get_or_create(
             client=self.client,
+            request_id=self.client.config.request_id,
             context_keys={"id": f"{context_id}"},
             use_llm_cache=use_llm_cache,
             use_action_cache=use_action_cache,

--- a/src/steamship/data/block.py
+++ b/src/steamship/data/block.py
@@ -287,6 +287,13 @@ class Block(CamelModel):
             tag_kind=DocTag.CHAT, tag_name=ChatTag.CHAT_ID, string_value=chat_id
         )
 
+    def set_request_id(self, request_id: Optional[str]):
+        if not request_id or len(request_id.strip()) == 0:
+            return
+        return self._one_time_set_tag(
+            tag_kind="request-id", tag_name=request_id, string_value=request_id
+        )
+
     @property
     def thread_id(self) -> Optional[str]:
         return get_tag_value_key(

--- a/src/steamship/data/file.py
+++ b/src/steamship/data/file.py
@@ -351,7 +351,7 @@ class File(CamelModel):
         is appended to this client-side File as well for convenience.
         """
         block = Block.create(
-            self.client,
+            client=self.client,
             file_id=self.id,
             text=text,
             tags=tags,
@@ -360,7 +360,7 @@ class File(CamelModel):
             mime_type=mime_type,
             public_data=public_data,
         )
-        self.blocks.append(block)
+        self.refresh()
         return block
 
     def set_public_data(self, public_data: bool):

--- a/src/steamship/data/tags/tag_constants.py
+++ b/src/steamship/data/tags/tag_constants.py
@@ -30,6 +30,7 @@ class TagKind(str, Enum):
     CHAT = "chat"
     CHAT_HISTORY_CONTEXT = "chat-history-context"
     MESSAGE_ID = "message-id"
+    STATUS_MESSAGE = "status-message"
     AGENT_STATUS_MESSAGE = "agent-status-message"
     TOOL_STATUS_MESSAGE = "tool-status-message"
     LLM_STATUS_MESSAGE = "llm-status-message"

--- a/src/steamship/data/tags/tag_constants.py
+++ b/src/steamship/data/tags/tag_constants.py
@@ -305,3 +305,6 @@ class ChatTag(str, Enum):
 
     # A message should be marked as kind=CHAT/name=MESSAGE
     MESSAGE = "message"
+
+    # Used to signal that an individual request was considered complete
+    REQUEST_COMPLETE = "request-complete"

--- a/src/steamship/utils/repl.py
+++ b/src/steamship/utils/repl.py
@@ -14,6 +14,8 @@ from steamship import Block, Steamship, Task, TaskState
 from steamship.agents.logging import AgentLogging
 from steamship.agents.schema import AgentContext, Tool
 from steamship.agents.service.agent_service import AgentService
+from steamship.data import TagKind, TagValueKey
+from steamship.data.tags.tag_utils import get_tag
 from steamship.data.workspace import Workspace
 from steamship.invocable.dev_logging_handler import DevelopmentLoggingHandler
 
@@ -202,10 +204,23 @@ class AgentREPL(SteamshipREPL):
         history = agent_ctx.chat_history
         history.refresh()
         for block in history.messages:
-            if block.is_text():
-                print(f"[{block.chat_role}] {block.text}")
+            chat_role = block.chat_role
+            status_msg = get_tag(block.tags, kind=TagKind.STATUS_MESSAGE)
+            if not chat_role and not status_msg:
+                continue
+
+            if chat_role:
+                prefix = f"[{chat_role}]"
             else:
-                print(f"[{block.chat_role}] {block.id} ({block.mime_type})")
+                if value := status_msg.value:
+                    prefix = f"[{value.get(TagValueKey.STRING_VALUE)} status]"
+                else:
+                    prefix = "[status]"
+
+            if block.is_text():
+                print(f"{prefix} {block.text}")
+            else:
+                print(f"{prefix} {block.id} ({block.mime_type})")
         print("\n------------------------------\n")
         exit(0)
 

--- a/tests/steamship_tests/agents/test_agent_limits.py
+++ b/tests/steamship_tests/agents/test_agent_limits.py
@@ -18,9 +18,6 @@ class MyEverythingTool(Tool):
 
 
 class MyPredictableAgent(Agent):
-    def record_action_run(self, action: Action, context: AgentContext):
-        super().record_action_run()
-
     def next_action(self, context: AgentContext) -> Action:
         return Action(tool="everything", input=[])
 

--- a/tests/steamship_tests/agents/test_agent_limits.py
+++ b/tests/steamship_tests/agents/test_agent_limits.py
@@ -18,6 +18,9 @@ class MyEverythingTool(Tool):
 
 
 class MyPredictableAgent(Agent):
+    def record_action_run(self, action: Action, context: AgentContext):
+        super().record_action_run()
+
     def next_action(self, context: AgentContext) -> Action:
         return Action(tool="everything", input=[])
 

--- a/tests/steamship_tests/agents/test_agent_service.py
+++ b/tests/steamship_tests/agents/test_agent_service.py
@@ -244,42 +244,42 @@ def test_context_logging_to_chat_history_everything(client: Steamship):
         assert has_status_message(chat_history.messages, RoleTag.TOOL)
 
 
-@pytest.mark.usefixtures("client")
-def test_non_duplicate_messages(client: Steamship):
-    example_agent_service_path = (
-        SRC_PATH / "steamship" / "agents" / "examples" / "example_assistant.py"
-    )
-    version_config_template = {
-        "model_name": {"type": "string"},
-    }
-    instance_config = {"model_name": "gpt-3.5-turbo"}
-    with deploy_package(
-        client=client,
-        py_path=example_agent_service_path,
-        version_config_template=version_config_template,
-        instance_config=instance_config,
-        wait_for_init=True,
-    ) as (
-        _,
-        _,
-        agent_service,
-    ):
-        context_id = "test-for-message-duplication"
-        agent_service.blocks_from_invoke(
-            "prompt", prompt="who is the president of Taiwan?", context_id=context_id
+def test_non_duplicate_messages():
+    with Steamship.temporary_workspace() as client:
+        example_agent_service_path = (
+            SRC_PATH / "steamship" / "agents" / "examples" / "example_assistant.py"
         )
-        final_blocks = agent_service.blocks_from_invoke(
-            "prompt", prompt="totally. thanks.", context_id=context_id
-        )
+        version_config_template = {
+            "model_name": {"type": "string"},
+        }
+        instance_config = {"model_name": "gpt-3.5-turbo"}
+        with deploy_package(
+            client=client,
+            py_path=example_agent_service_path,
+            version_config_template=version_config_template,
+            instance_config=instance_config,
+            wait_for_init=True,
+        ) as (
+            _,
+            _,
+            agent_service,
+        ):
+            context_id = "test-for-message-duplication"
+            agent_service.blocks_from_invoke(
+                "prompt", prompt="who is the president of Taiwan?", context_id=context_id
+            )
+            final_blocks = agent_service.blocks_from_invoke(
+                "prompt", prompt="totally. thanks.", context_id=context_id
+            )
 
-        assert (
-            len(final_blocks) == 1
-        ), f"There should only be a single block. Got: {len(final_blocks)}"
-        text = final_blocks[0].text
-        assert "\n" not in text, f"Unexpected response. Should be single line. Got: {text}"
-        assert (
-            "function_call" not in text
-        ), f"Unexpected response. Should not include function call. Got: {text}"
+            assert (
+                len(final_blocks) == 1
+            ), f"There should only be a single block. Got: {len(final_blocks)}"
+            text = final_blocks[0].text
+            assert "\n" not in text, f"Unexpected response. Should be single line. Got: {text}"
+            assert (
+                "function_call" not in text
+            ), f"Unexpected response. Should not include function call. Got: {text}"
 
 
 @pytest.mark.usefixtures("client")

--- a/tests/steamship_tests/agents/test_agent_service.py
+++ b/tests/steamship_tests/agents/test_agent_service.py
@@ -163,7 +163,7 @@ def has_status_message(blocks: List[Block], role: RoleTag) -> bool:
     for b in blocks:
         for t in b.tags:
             if (
-                t.kind == TagKind.CHAT
+                t.kind == TagKind.STATUS_MESSAGE
                 and t.name == ChatTag.ROLE
                 and t.value.get(TagValueKey.STRING_VALUE) == role
             ):

--- a/tests/steamship_tests/agents/test_agent_service.py
+++ b/tests/steamship_tests/agents/test_agent_service.py
@@ -296,25 +296,87 @@ def test_async_prompt(client: Steamship):
         agent_service,
     ):
         context_id = "some_async_fun"
-        streaming_resp = agent_service.invoke(
-            "async_prompt",
-            prompt="who is the current president of the United States?",
-            context_id=context_id,
-        )
+        try:
+            streaming_resp = agent_service.invoke(
+                "async_prompt",
+                prompt="who is the current president of the United States?",
+                context_id=context_id,
+            )
+        except SteamshipError as error:
+            pytest.fail(f"failed request: {error}")
 
         assert streaming_resp is not None
         assert streaming_resp["file"] is not None
         assert streaming_resp["task"] is not None
 
         file = File(client=client, **(streaming_resp["file"]))
-        task = Task(client=client, **(streaming_resp["task"]))
+        streaming_task = Task(client=client, **(streaming_resp["task"]))
 
         original_len = len(file.blocks)
+        req_id = streaming_task.request_id
 
-        task.wait()
-        assert task.state in [TaskState.succeeded, TaskState.failed]
+        import sseclient
+
+        # import requests
+        sse_source = f"{client.config.api_base}file/{file.id}/stream?tagKindFilter=request-id&tagNameFilter={req_id}"
+        print(f"\nSSE SOURCE: {sse_source}")
+        headers = {
+            "Accept": "text/event-stream",
+            "X-Workspace-Id": client.get_workspace().id,
+            "Authorization": f"Bearer {client.config.api_key.get_secret_value()}",
+        }
+        print(headers)
+        # sse_response = requests.get(sse_source, stream=True, headers=headers)
+
+        # TODO: it is concerning that putting this block after a Task completes is the only way it seems to work
+        # import urllib3
+        # timeout = urllib3.Timeout(connect=2.0, read=10.0)
+        # http = urllib3.PoolManager(timeout=timeout)
+        # sse_response = http.request('GET', sse_source, preload_content=False, headers=headers)
+        #
+        # sse_client = sseclient.SSEClient(sse_response)
+        # num_events = 0
+        # try:
+        #     for event in sse_client.events():
+        #         num_events += 1
+        #
+        #         # TODO: should we assert these are blockCreated events?
+        #         print(event)
+        # except urllib3.exceptions.ReadTimeoutError:
+        #     # TODO: this is required to get a termination on the streaming wait.
+        #     # TODO: do we have a way to signal events have stopped?
+        #     pass
+
+        try:
+            streaming_task.wait_until_completed()
+        except SteamshipError as error:
+            pytest.fail(f"Task failed to complete: {error}")
+
+        assert streaming_task.state in [TaskState.succeeded]
+
+        # TODO: it is concerning that putting this block after a Task completes is the only way it seems to work
+        import urllib3
+
+        timeout = urllib3.Timeout(connect=2.0, read=10.0)
+        http = urllib3.PoolManager(timeout=timeout)
+        sse_response = http.request("GET", sse_source, preload_content=False, headers=headers)
+
+        sse_client = sseclient.SSEClient(sse_response)
+        num_events = 0
+        try:
+            for event in sse_client.events():
+                num_events += 1
+
+                # TODO: should we assert these are blockCreated events?
+                print(event)
+        except urllib3.exceptions.ReadTimeoutError:
+            # TODO: this is required to get a termination on the streaming wait.
+            # TODO: do we have a way to signal events have stopped?
+            pass
 
         file.refresh()
         assert (
             len(file.blocks) > original_len
         ), "File should have increased in size during AgentService execution"
+
+        assert num_events == 13

--- a/tests/steamship_tests/agents/test_agent_service.py
+++ b/tests/steamship_tests/agents/test_agent_service.py
@@ -5,7 +5,7 @@ from pydantic.fields import PrivateAttr
 from steamship_tests import SRC_PATH
 from steamship_tests.utils.deployables import deploy_package
 
-from steamship import Block, Steamship, SteamshipError, Task
+from steamship import Block, File, Steamship, SteamshipError, Task, TaskState
 from steamship.agents.functional import FunctionsBasedAgent
 from steamship.agents.llms.openai import ChatOpenAI
 from steamship.agents.schema import Action, AgentContext, Tool
@@ -284,3 +284,37 @@ def test_non_duplicate_messages(client: Steamship):
         assert (
             "function_call" not in text
         ), f"Unexpected response. Should not include function call. Got: {text}"
+
+
+def test_async_prompt(client: Steamship):
+    example_agent_service_path = (
+        SRC_PATH / "steamship" / "agents" / "examples" / "example_assistant.py"
+    )
+    with deploy_package(client, example_agent_service_path, wait_for_init=True) as (
+        _,
+        _,
+        agent_service,
+    ):
+        context_id = "some_async_fun"
+        streaming_resp = agent_service.invoke(
+            "async_prompt",
+            prompt="who is the current president of the United States?",
+            context_id=context_id,
+        )
+
+        assert streaming_resp is not None
+        assert streaming_resp["file"] is not None
+        assert streaming_resp["task"] is not None
+
+        file = File(client=client, **(streaming_resp["file"]))
+        task = Task(client=client, **(streaming_resp["task"]))
+
+        original_len = len(file.blocks)
+
+        task.wait()
+        assert task.state in [TaskState.succeeded, TaskState.failed]
+
+        file.refresh()
+        assert (
+            len(file.blocks) > original_len
+        ), "File should have increased in size during AgentService execution"

--- a/tests/steamship_tests/agents/test_agent_service.py
+++ b/tests/steamship_tests/agents/test_agent_service.py
@@ -1,7 +1,9 @@
 import json
+import time
 from typing import Any, List, Union
 
 import pytest
+import requests
 from pydantic.fields import PrivateAttr
 from steamship_tests import SRC_PATH
 from steamship_tests.utils.deployables import deploy_package
@@ -250,6 +252,7 @@ def test_context_logging_to_chat_history_everything(client: Steamship):
         assert has_status_message(chat_history.messages, RoleTag.TOOL)
 
 
+<<<<<<< HEAD
 @pytest.mark.usefixtures("client")
 def test_non_duplicate_messages(client: Steamship):
     example_agent_service_path = (
@@ -315,10 +318,12 @@ def test_async_prompt(client: Steamship):
         streaming_task = Task(client=client, **(streaming_resp["task"]))
 
         original_len = len(file.blocks)
-        req_id = streaming_task.request_id
 
-        import requests
-        import sseclient
+        while streaming_task.state in [TaskState.waiting]:
+            # tight loop to check on waiting status of Task
+            # we only want to try to stream once a Task **starts**
+            time.sleep(0.1)
+            streaming_task.refresh()
 
         sse_source = f"{client.config.api_base}file/{file.id}/stream?tagKindFilter=request-id&tagNameFilter={req_id}&timeoutSeconds=30"
         headers = {
@@ -332,8 +337,9 @@ def test_async_prompt(client: Steamship):
         except SteamshipError as error:
             pytest.fail(f"Task failed to complete: {error}")
 
-        assert streaming_task.state in [TaskState.succeeded]
+        assert streaming_task.state in [TaskState.running]
 
+        block_ids_seen = []
         llm_prompt_event_count = 0
         function_selection_event = False
         tool_execution_event = False
@@ -341,58 +347,47 @@ def test_async_prompt(client: Steamship):
         assistant_chat_response_event = False
 
         # TODO: it is concerning that putting this block after a Task completes is the only way it seems to work
-        sse_response = requests.get(sse_source, stream=True, headers=headers, timeout=45)
-        sse_client = sseclient.SSEClient(sse_response)
         num_events = 0
-        try:
-            # sse event format: {'blockCreated': {'blockId': '<uuid>', 'createdAt': '2023-09-25T16:12:54Z'}}
-            for event in sse_client.events():
-                num_events += 1
-                block_creation_event = json.loads(event.data)
-                block_created = block_creation_event["blockCreated"]
-                block_id = block_created["blockId"]
-                block = Block.get(client=client, _id=block_id)
-                for t in block.tags:
-                    match t.kind:
-                        case TagKind.LLM_STATUS_MESSAGE:
-                            if t.name == AgentLogging.PROMPT:
-                                llm_prompt_event_count += 1
-                        case TagKind.FUNCTION_SELECTION:
-                            if t.name == "SearchTool":
-                                function_selection_event = True
-                        case TagKind.TOOL_STATUS_MESSAGE:
-                            tool_execution_event = True
-                        case TagKind.ROLE:
-                            if t.name == RoleTag.FUNCTION:
-                                function_complete_event = True
-                        case TagKind.CHAT:
-                            if (
-                                t.name == ChatTag.ROLE
-                                and t.value.get(TagValueKey.STRING_VALUE, "") == RoleTag.ASSISTANT
-                            ):
-                                assistant_chat_response_event = True
-        except requests.exceptions.ConnectionError as err:
-            sse_response.close()
-            # TODO: this is required to get a termination on the streaming wait.
-            # TODO: do we have a way to signal events have stopped?
-            if "Read timed out." in str(err):
-                pass
-            else:
-                raise err
-        except Exception as err:
-            sse_response.close()
-            raise err
-        else:
-            sse_response.close()
+        # sse event format: {'blockCreated': {'blockId': '<uuid>', 'createdAt': '2023-09-25T16:12:54Z'}}
+        for event in events_while_running(client, streaming_task, file):
+            # TODO: it seems like event ids aren't consistent
+            block_creation_event = json.loads(event.data)
+            block_created = block_creation_event["blockCreated"]
+            block_id = block_created["blockId"]
+            if block_id in block_ids_seen:
+                continue
+            block_ids_seen.append(block_id)
+            num_events += 1
+            block = Block.get(client=client, _id=block_id)
+            for t in block.tags:
+                match t.kind:
+                    case TagKind.LLM_STATUS_MESSAGE:
+                        if t.name == AgentLogging.PROMPT:
+                            llm_prompt_event_count += 1
+                    case TagKind.FUNCTION_SELECTION:
+                        if t.name == "SearchTool":
+                            function_selection_event = True
+                    case TagKind.TOOL_STATUS_MESSAGE:
+                        tool_execution_event = True
+                    case TagKind.ROLE:
+                        if t.name == RoleTag.FUNCTION:
+                            function_complete_event = True
+                    case TagKind.CHAT:
+                        if (
+                            t.name == ChatTag.ROLE
+                            and t.value.get(TagValueKey.STRING_VALUE, "") == RoleTag.ASSISTANT
+                        ):
+                            assistant_chat_response_event = True
 
         file.refresh()
         assert (
             len(file.blocks) > original_len
         ), "File should have increased in size during AgentService execution"
 
+        print(f"num events: {num_events}")
         assert num_events > 0, "Events should have been streamed during execution"
         assert llm_prompt_event_count == 2, (
-            "At least 3 llm prompts should have happened (first for tool selection, "
+            "At least 2 llm prompts should have happened (first for tool selection, "
             "second for generating final answer)"
         )
         assert function_selection_event is True, "SearchTool should have been selected"
@@ -401,3 +396,65 @@ def test_async_prompt(client: Steamship):
         assert (
             assistant_chat_response_event is True
         ), "Agent should have sent the assistant chat response"
+        # assert False
+
+
+def events_while_running(client: Steamship, task: Task, file: File):
+    req_id = task.request_id
+    while task.state in [TaskState.running]:
+        yields = 0
+        # NOTE: I'm convinced that this generator of generators approach is not correct, but...
+        event_gen = events_for_file(client, file.id, req_id)
+        try:
+            for event in event_gen:
+                yields += 1
+                yield event
+        except StopIteration:
+            # not ready to stream, or done streaming.
+            print("stop iteration")
+            pass
+        print(f"total yields: {yields}")
+        # This is not ideal, but it at least should make sure we get **all** events
+        task.refresh()
+    print(f"task is complete: {task.state}")
+
+
+def events_for_file(client: Steamship, file_id: str, req_id: str):
+    print("getting events for file.")
+    import sseclient
+
+    sse_source = f"{client.config.api_base}file/{file_id}/stream?tagKindFilter=request-id&tagNameFilter={req_id}&timeoutSeconds=30"
+    headers = {
+        "Accept": "text/event-stream",
+        "X-Workspace-Id": client.get_workspace().id,
+        "Authorization": f"Bearer {client.config.api_key.get_secret_value()}",
+    }
+
+    sse_response = requests.get(sse_source, stream=True, headers=headers, timeout=45)
+    sse_client = sseclient.SSEClient(sse_response)
+    yields = 0
+    try:
+        for event in sse_client.events():
+            yields += 1
+            print(f"--> yield: {yields}")
+            yield event
+    except requests.exceptions.ConnectionError as err:
+        if "Read timed out." in str(err):
+            print("-- timeout")
+            pass
+        else:
+            sse_client.close()
+            sse_response.close()
+            raise err
+    except StopIteration:
+        print("-- stop iteration")
+        sse_client.close()
+        sse_response.close()
+    except Exception as err:
+        sse_client.close()
+        sse_response.close()
+        raise err
+    else:
+        print("-- successful close of stream.")
+        sse_client.close()
+        sse_response.close()

--- a/tests/steamship_tests/agents/test_agent_with_final_tool.py
+++ b/tests/steamship_tests/agents/test_agent_with_final_tool.py
@@ -70,5 +70,5 @@ def test_final_tool_assistant(invocable_handler: Callable[[str, str, Optional[di
     assert food_suggestion
     assert food_suggestion[0].get("text")
 
-    # The agent responded with a FULL sentence. Something like: "I suggest you try some apples!"
+    # The agent responded with a FULL sentence. Something like: "I suggest you try Peru!"
     assert food_suggestion[0].get("text") == "Peru"

--- a/tests/steamship_tests/agents/test_functions_based_agent.py
+++ b/tests/steamship_tests/agents/test_functions_based_agent.py
@@ -172,7 +172,8 @@ def test_proper_message_selection(client: Steamship):
         message_selector=MessageWindowMessageSelector(k=2),
     )
 
-    # simulate prompting and tool selecttion
+    # simulate prompting and tool selection
+    agent_context.chat_history.append_system_message(text=test_agent.PROMPT)
     agent_context.chat_history.append_user_message(text="Who is the current president of Taiwan?")
     agent_context.chat_history.append_agent_message(text="Ignore me.")
     agent_context.chat_history.append_llm_message(text="OpenAI ChatComplete...")

--- a/tests/steamship_tests/agents/test_functions_based_agent.py
+++ b/tests/steamship_tests/agents/test_functions_based_agent.py
@@ -89,7 +89,7 @@ def test_functions_based_agent_no_appropriate_tool_with_no_memory(client: Steams
     ctx_keys = {"id": "testing-foo"}
     ctx = AgentContext.get_or_create(client=client, context_keys=ctx_keys, searchable=False)
     ctx.chat_history.append_user_message(
-        "make a 10 second movie about a hamburger that learns to talk"
+        "record an original 30 minute song about a hamburger that learns to talk. do not find an existing one."
     )
 
     action = agent.next_action(context=ctx)

--- a/tests/steamship_tests/utils/fixtures.py
+++ b/tests/steamship_tests/utils/fixtures.py
@@ -26,8 +26,10 @@ def client() -> Steamship:
           pass
     """
     steamship = get_steamship_client()
-    workspace = Workspace.create(client=steamship)
-    new_client = get_steamship_client(workspace_id=workspace.id)
+    workspace_handle = random_name()
+    workspace = Workspace.create(client=steamship, handle=workspace_handle)
+    # NOTE: get_steamship_client takes either `workspace_handle` or `workspace_id`, but NOT `workspace` as a keyword arg
+    new_client = get_steamship_client(workspace_handle=workspace_handle)
     yield new_client
     workspace.delete()
 

--- a/tests/steamship_tests/utils/fixtures.py
+++ b/tests/steamship_tests/utils/fixtures.py
@@ -1,13 +1,13 @@
 from typing import Callable, Optional, Type
 
 import pytest
+from steamship_tests.utils.client import get_steamship_client
+from steamship_tests.utils.random import random_name
 
 from steamship import Steamship, Workspace
 from steamship.invocable import InvocableRequest, Invocation, InvocationContext, LoggingConfig
 from steamship.invocable.invocable import Invocable
 from steamship.invocable.lambda_handler import create_safe_handler as _create_handler
-from steamship_tests.utils.client import get_steamship_client
-from steamship_tests.utils.random import random_name
 
 
 @pytest.fixture()

--- a/tests/steamship_tests/utils/fixtures.py
+++ b/tests/steamship_tests/utils/fixtures.py
@@ -2,12 +2,12 @@ from typing import Callable, Optional, Type
 
 import pytest
 from steamship_tests.utils.client import get_steamship_client
-from steamship_tests.utils.random import random_name
 
 from steamship import Steamship, Workspace
 from steamship.invocable import InvocableRequest, Invocation, InvocationContext, LoggingConfig
 from steamship.invocable.invocable import Invocable
 from steamship.invocable.lambda_handler import create_safe_handler as _create_handler
+from steamship_tests.utils.random import random_name
 
 
 @pytest.fixture()
@@ -62,20 +62,22 @@ def invocable_handler(request) -> Callable[[str, str, Optional[dict]], dict]:
     # NOTE: get_steamship_client takes either `workspace_handle` or `workspace_id`, but NOT `workspace` as a keyword arg
     new_client = get_steamship_client(workspace_handle=workspace_handle)
 
-    def handle(verb: str, invocation_path: str, arguments: Optional[dict] = None) -> dict:
-        _handler = _create_handler(known_invocable_for_testing=invocable)
-        invocation = Invocation(
-            http_verb=verb, invocation_path=invocation_path, arguments=arguments or {}
-        )
-        logging_config = LoggingConfig(logging_host="none", logging_port="none")
-        request = InvocableRequest(
-            client_config=new_client.config,
-            invocation=invocation,
-            logging_config=logging_config,
-            invocation_context=InvocationContext(invocable_handle="foo"),
-        )
-        event = request.dict(by_alias=True)
-        return _handler(event, None)
+    with Steamship.temporary_workspace() as new_client:
 
-    yield handle
+        def handle(verb: str, invocation_path: str, arguments: Optional[dict] = None) -> dict:
+            _handler = _create_handler(known_invocable_for_testing=invocable)
+            invocation = Invocation(
+                http_verb=verb, invocation_path=invocation_path, arguments=arguments or {}
+            )
+            logging_config = LoggingConfig(logging_host="none", logging_port="none")
+            request = InvocableRequest(
+                client_config=new_client.config,
+                invocation=invocation,
+                logging_config=logging_config,
+                invocation_context=InvocationContext(invocable_handle="foo"),
+            )
+            event = request.dict(by_alias=True)
+            return _handler(event, None)
+
+        yield handle
     workspace.delete()


### PR DESCRIPTION
This PR establishes an initial implementation of streaming utilities for `AgentService` endpoints, based on `FunctionsBasedAgent` runs. This will allow clients to invoke an agent run through an async endpoint and stream, via SSE, block creation events related to the agent's execution. These events can include status messages (from Agents and Tools) as well as generated blocks (from LLMs and Tools). 

With this code, new async endpoints can be exposed with code like the following:

```python
    @post("async_prompt")
    def async_prompt(
        self, prompt: Optional[str] = None, context_id: Optional[str] = None, **kwargs
    ) -> StreamingResponse:
        ctx_id, history_file = self._streaming_context_id_and_file(context_id=context_id, **kwargs)
        task = self.invoke_later(
            "/prompt", arguments={"prompt": prompt, "context_id": ctx_id, **kwargs}
        )
        return StreamingResponse(task=task, file=history_file)
```

The PR ensures all `Block`s created in the service of a `run_agent` call are tagged with the proper `request-id`, and that all calls to the LLM are streaming-compatible.

A test is provided that demonstrates an approach to consuming a stream of events, based on the sseclient-py library. A Generator is constructed that emits `Block`s until a terminal block for a request is found in the stream.