### PR TITLE
fix(telegram): ensure proper bot API base

### DIFF
--- a/src/steamship/agents/mixins/transports/telegram.py
+++ b/src/steamship/agents/mixins/transports/telegram.py
@@ -296,7 +296,7 @@ class TelegramTransport(Transport):
                 # This is a special case for our testing pipeline -- it contains a mock Telegram server.
                 return api_base
             else:
-                return f"{api_base}{bot_token}"
+                return f"{api_base[:-1]}{bot_token}"
         else:
             return None
 

--- a/tests/steamship_tests/agents/transports/test_telegram.py
+++ b/tests/steamship_tests/agents/transports/test_telegram.py
@@ -5,12 +5,25 @@ from steamship_tests import PACKAGES_PATH
 from steamship_tests.utils.deployables import deploy_package
 
 from steamship import File, PackageInstance, Steamship
+from steamship.agents.mixins.transports.telegram import TelegramTransport, TelegramTransportConfig
+from steamship.agents.service.agent_service import AgentService
 
 config_template = {
     "telegram_token": {"type": "string", "default": ""},
     "telegram_api_base": {"type": "string", "default": ""},
     "slack_api_base": {"type": "string", "default": ""},
 }
+
+
+def test_telegram_api_base():
+    with Steamship.temporary_workspace() as client:
+        transport = TelegramTransport(
+            client=client,
+            agent_service=AgentService(client=client),
+            config=TelegramTransportConfig(),
+        )
+        transport.bot_token = "TOKEN"  # noqa: S105
+        assert transport.get_api_root() == "https://api.telegram.org/botTOKEN"
 
 
 @pytest.mark.usefixtures("client")


### PR DESCRIPTION
I _think_ that in the refactor in https://github.com/steamship-core/python-client/commit/05a8f0e68cc0c343e70915849d2ea3551091ae85 the behavior of the base API for Telegram became to use a `/` in between `bot` and the supplied token. 

Per https://core.telegram.org/bots/api#making-requests, the API base should be:

`https://api.telegram.org/bot<token>/METHOD_NAME`

Note the lack of `/` between `bot` and `<token>`