### PR TITLE
fix(history): add emit fn to transports that appends to chat history

### DIFF
--- a/src/steamship/agents/mixins/transports/slack.py
+++ b/src/steamship/agents/mixins/transports/slack.py
@@ -470,7 +470,8 @@ class SlackTransport(Transport):
                         incoming_message_ts=incoming_message.message_id,
                         thread_ts=thread_ts,
                     ),
-                    build_context_appending_emit_func(context=context),
+                    # allow slack access to blocks on emit (making them public)
+                    build_context_appending_emit_func(context=context, make_blocks_public=True),
                 ]
 
                 # Add an LLM to the context, using the Agent's if it exists.

--- a/src/steamship/agents/mixins/transports/slack.py
+++ b/src/steamship/agents/mixins/transports/slack.py
@@ -464,15 +464,18 @@ class SlackTransport(Transport):
                     context.metadata["slack"]["thread_ts"] = thread_ts
 
                 # TODO: For truly async support, this emit fn will need to be wired in at the Agent level.
-                context.emit_funcs = [
+                context.emit_funcs.append(
                     self.build_emit_func(
                         chat_id=chat_id,
                         incoming_message_ts=incoming_message.message_id,
                         thread_ts=thread_ts,
-                    ),
+                    )
+                )
+
+                context.emit_funcs.append(
                     # allow slack access to blocks on emit (making them public)
                     build_context_appending_emit_func(context=context, make_blocks_public=True),
-                ]
+                )
 
                 # Add an LLM to the context, using the Agent's if it exists.
                 llm = None

--- a/src/steamship/agents/mixins/transports/slack.py
+++ b/src/steamship/agents/mixins/transports/slack.py
@@ -11,7 +11,7 @@ from steamship import Block, Steamship
 from steamship.agents.llms import OpenAI
 from steamship.agents.mixins.transports.transport import Transport
 from steamship.agents.schema import EmitFunc, Metadata
-from steamship.agents.service.agent_service import AgentService
+from steamship.agents.service.agent_service import AgentService, build_context_appending_emit_func
 from steamship.agents.utils import with_llm
 from steamship.invocable import Config, InvocableResponse, get, post
 from steamship.utils.kv_store import KeyValueStore
@@ -450,39 +450,40 @@ class SlackTransport(Transport):
             chat_id = incoming_message.chat_id
             thread_ts = incoming_message.thread_id
             context_id = self._get_context_id_for_response(chat_id, thread_ts)
-            context = self.agent_service.build_default_context(context_id=context_id)
 
-            context.chat_history.append_user_message(
-                text=incoming_message.text, tags=incoming_message.tags
-            )
-
-            context.metadata["slack"] = {
-                "channel": chat_id,
-                "message_ts": incoming_message.message_id,
-            }
-            if thread_ts:
-                context.metadata["slack"]["thread_ts"] = thread_ts
-
-            # TODO: For truly async support, this emit fn will need to be wired in at the Agent level.
-            context.emit_funcs = [
-                self.build_emit_func(
-                    chat_id=chat_id,
-                    incoming_message_ts=incoming_message.message_id,
-                    thread_ts=thread_ts,
+            with self.agent_service.build_default_context(context_id=context_id) as context:
+                context.chat_history.append_user_message(
+                    text=incoming_message.text, tags=incoming_message.tags
                 )
-            ]
 
-            # Add an LLM to the context, using the Agent's if it exists.
-            llm = None
-            agent = self.agent_service.get_default_agent()
-            if hasattr(agent, "llm"):
-                llm = agent.llm
-            else:
-                llm = OpenAI(client=self.client)
+                context.metadata["slack"] = {
+                    "channel": chat_id,
+                    "message_ts": incoming_message.message_id,
+                }
+                if thread_ts:
+                    context.metadata["slack"]["thread_ts"] = thread_ts
 
-            context = with_llm(context=context, llm=llm)
+                # TODO: For truly async support, this emit fn will need to be wired in at the Agent level.
+                context.emit_funcs = [
+                    self.build_emit_func(
+                        chat_id=chat_id,
+                        incoming_message_ts=incoming_message.message_id,
+                        thread_ts=thread_ts,
+                    ),
+                    build_context_appending_emit_func(context=context),
+                ]
 
-            self.agent_service.run_agent(agent, context)
+                # Add an LLM to the context, using the Agent's if it exists.
+                llm = None
+                agent = self.agent_service.get_default_agent()
+                if hasattr(agent, "llm"):
+                    llm = agent.llm
+                else:
+                    llm = OpenAI(client=self.client)
+
+                context = with_llm(context=context, llm=llm)
+
+                self.agent_service.run_agent(agent, context)
 
         except BaseException as e:
             logging.error(e)

--- a/src/steamship/agents/mixins/transports/steamship_widget.py
+++ b/src/steamship/agents/mixins/transports/steamship_widget.py
@@ -67,7 +67,8 @@ class SteamshipWidgetTransport(Transport):
             )
             context.emit_funcs = [
                 self.save_for_emit,
-                build_context_appending_emit_func(context=context),
+                # allow web-app access to blocks on emit (making them public)
+                build_context_appending_emit_func(context=context, make_blocks_public=True),
             ]
 
             try:

--- a/src/steamship/agents/mixins/transports/telegram.py
+++ b/src/steamship/agents/mixins/transports/telegram.py
@@ -8,7 +8,7 @@ from pydantic import Field
 from steamship import Block, Steamship, SteamshipError
 from steamship.agents.mixins.transports.transport import Transport
 from steamship.agents.schema import EmitFunc, Metadata
-from steamship.agents.service.agent_service import AgentService
+from steamship.agents.service.agent_service import AgentService, build_context_appending_emit_func
 from steamship.invocable import Config, InvocableResponse, post
 from steamship.utils.kv_store import KeyValueStore
 
@@ -237,21 +237,17 @@ class TelegramTransport(Transport):
         try:
             incoming_message = self.parse_inbound(message)
             if incoming_message is not None:
-                context = self.agent_service.build_default_context(chat_id)
+                with self.agent_service.build_default_context(chat_id) as context:
+                    context.chat_history.append_user_message(
+                        text=incoming_message.text, tags=incoming_message.tags
+                    )
 
-                context.chat_history.append_user_message(
-                    text=incoming_message.text, tags=incoming_message.tags
-                )
-                context.emit_funcs = [self.build_emit_func(chat_id=chat_id)]
+                    context.emit_funcs = [
+                        self.build_emit_func(chat_id=chat_id),
+                        build_context_appending_emit_func(context=context),
+                    ]
 
-                response = self.agent_service.run_agent(
-                    self.agent_service.get_default_agent(), context
-                )
-                if response is not None:
-                    self.send(response)
-                else:
-                    # Do nothing here; this could be a message we intentionally don't want to respond to (ex. an image or file upload)
-                    pass
+                    self.agent_service.run_agent(self.agent_service.get_default_agent(), context)
             else:
                 # Do nothing here; this could be a message we intentionally don't want to respond to (ex. an image or file upload)
                 pass

--- a/src/steamship/agents/mixins/transports/telegram.py
+++ b/src/steamship/agents/mixins/transports/telegram.py
@@ -244,7 +244,8 @@ class TelegramTransport(Transport):
 
                     context.emit_funcs = [
                         self.build_emit_func(chat_id=chat_id),
-                        build_context_appending_emit_func(context=context),
+                        # allow telegram access to blocks on emit (making them public)
+                        build_context_appending_emit_func(context=context, make_blocks_public=True),
                     ]
 
                     self.agent_service.run_agent(self.agent_service.get_default_agent(), context)

--- a/src/steamship/agents/service/agent_service.py
+++ b/src/steamship/agents/service/agent_service.py
@@ -20,17 +20,17 @@ def build_context_appending_emit_func(
     an assistant response to a USER.
     """
 
-    def new_emit_func(blocks: List[Block], metadata: Metadata):
+    def chat_history_append_func(blocks: List[Block], metadata: Metadata):
         for block in blocks:
             block.set_public_data(make_blocks_public)
             context.chat_history.append_assistant_message(
                 text=block.text,
                 tags=block.tags,
-                url=block.raw_data_url or block.url or block.content_url,
+                url=block.raw_data_url or block.url or block.content_url or None,
                 mime_type=block.mime_type,
             )
 
-    return new_emit_func
+    return chat_history_append_func
 
 
 class AgentService(PackageService):
@@ -240,7 +240,7 @@ class AgentService(PackageService):
             f"Completed agent run. Result: {len(action.output or [])} blocks. {output_text_length} total text length. Emitting on {len(context.emit_funcs)} functions."
         )
         for func in context.emit_funcs:
-            logging.info(f"Emitting via function: {func.__name__}")
+            logging.info(f"Emitting via function '{func.__name__}' for context: {context.id}")
             func(action.output, context.metadata)
 
     def set_default_agent(self, agent: Agent):

--- a/src/steamship/data/block.py
+++ b/src/steamship/data/block.py
@@ -178,6 +178,9 @@ class Block(CamelModel):
     def raw(self):
         if self.content_url is not None:
             return requests.get(self.content_url).content
+        elif self.client is None or self.id is None:
+            # guard against transient block raw()s
+            return None
         else:
             return self.client.post(
                 "block/raw",
@@ -245,10 +248,11 @@ class Block(CamelModel):
         """Return a URL at which the data content of this Block can be accessed.  If public_data is True,
         this content can be accessed without an API key.
         """
-        if self.client is not None:
-            return f"{self.client.config.api_base}block/{self.id}/raw"
-        else:
+        if self.client is None or self.id is None:
+            # guard against invalid URLs
             return None
+
+        return f"{self.client.config.api_base}block/{self.id}/raw"
 
     @property
     def chat_role(self) -> Optional[RoleTag]:


### PR DESCRIPTION
Existing transports were not appending messages sent back to users to the `ChatHistory`. This PR attempts to fix that by introducing a builder for an emit function that will do that directly. 