### PR TITLE
Add bot handle reporting to Telegram Transport

### DIFF
--- a/src/steamship/agents/mixins/transports/telegram.py
+++ b/src/steamship/agents/mixins/transports/telegram.py
@@ -80,12 +80,22 @@ class TelegramTransport(Transport):
                 f"Could not set webhook for bot. Webhook URL was {webhook_url}. Telegram response message: {response.text}"
             )
 
+    @post("telegram_bot_info")
+    def telegram_bot_info(self) -> dict:
+        api_root = self.get_api_root()
+        if not api_root:
+            raise SteamshipError(
+                message="Unable to fetch Telegram Bot info -- perhaps your bot token isn't set?"
+            )
+
+        return requests.get(api_root + "/getMe").json()
+
     @post("telegram_webhook_info")
     def telegram_webhook_info(self) -> dict:
         api_root = self.get_api_root()
         if not api_root:
             raise SteamshipError(
-                message="Unable to fetch Telegram API info -- perhaps your bot token isn't set?"
+                message="Unable to fetch Telegram Webhook info -- perhaps your bot token isn't set?"
             )
 
         return requests.get(api_root + "/getWebhookInfo").json()
@@ -294,7 +304,7 @@ class TelegramTransport(Transport):
         if bot_token:
             if ".steamship.run/" in api_base or ".apps.staging.steamship.com" in api_base:
                 # This is a special case for our testing pipeline -- it contains a mock Telegram server.
-                return api_base
+                return api_base[:-1]
             else:
                 return f"{api_base[:-1]}{bot_token}"
         else:

--- a/tests/assets/packages/transports/mock_telegram_api.py
+++ b/tests/assets/packages/transports/mock_telegram_api.py
@@ -84,3 +84,9 @@ class MockTelegramApi(PackageService):
             ],
         )
         return "OK"
+
+    @get("getMe", public=True)
+    def get_me(
+        self,
+    ) -> dict:  # realize str is wrong here, but seems to be what I get from the file upload to our server.
+        return {"username": "TestBot"}

--- a/tests/steamship_tests/agents/transports/test_telegram.py
+++ b/tests/steamship_tests/agents/transports/test_telegram.py
@@ -76,6 +76,9 @@ def test_telegram(client: Steamship):
             # The configuration provided a token, so the token should be reported as having been set.
             assert agent_instance.invoke("is_telegram_token_set") is True
 
+            # The telegram_bot_info should return {"username": "TestBot"}
+            assert agent_instance.invoke("telegram_bot_info") == {"username": "TestBot"}
+
             # Test that agent called instance_init and registered webhook
             files = File.query(client, f'kind "{MockTelegramApi.WEBHOOK_TAG}"').files
             assert len(files) == 1


### PR DESCRIPTION
It looks like back in June, the reporting method which returned information about the bot itself was removed from the transport -- probably accidentally.

This is used to generate a link in the web UI that tells you which bot you've connected your agent to.