### PR TITLE
New runs should exist in their own workspace

### DIFF
--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -272,7 +272,8 @@ def serve_local(  # noqa: C901
     client, user, manifest = initialize_and_get_client_and_prep_project()
 
     if workspace:
-        workspace_obj = Workspace.get(client, handle=workspace)
+        # Fetch/create a workspace if one was specified.
+        workspace_obj = Workspace.create(client, handle=workspace, fetch_if_exists=True)
     else:
         # Create a new workspace if none was specified.
         # Otherwise multiple runs co-mingle data in the `default` workspace.

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -280,6 +280,9 @@ def serve_local(  # noqa: C901
         workspace_obj = Workspace.create(client)
         workspace = workspace_obj.handle
 
+    # Now switch the workspace to the one just created.
+    client.switch_workspace(workspace)
+
     # Make sure we're running a package.
     if manifest.type != DeployableType.PACKAGE:
         click.secho(

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -274,7 +274,9 @@ def serve_local(  # noqa: C901
     if workspace:
         workspace_obj = Workspace.get(client, handle=workspace)
     else:
-        workspace_obj = Workspace.get(client)
+        # Create a new workspace if none was specified.
+        # Otherwise multiple runs co-mingle data in the `default` workspace.
+        workspace_obj = Workspace.create(client)
         workspace = workspace_obj.handle
 
     # Make sure we're running a package.
@@ -287,6 +289,9 @@ def serve_local(  # noqa: C901
     # Make sure we have a package name -- this allows us to register the running copy with the engine.
     deployer = PackageDeployer()
     deployable = deployer.create_or_fetch_deployable(client, user, manifest)
+
+    # Report the workspace we're running in
+    click.secho(f"🗃️ Workspace:  {workspace}")
 
     # Report the logs output file.
     click.secho(f"📝 Log file:   {dev_logging_handler.log_filename}")


### PR DESCRIPTION
@GitOnUp mentioned this was really surprising to him, and it does feel like bug:

Unless a workspace is specified, `ship run local` will always run the agent in the `default` workspace which means the data and chat histories from multiple runs will be commingled.

This PR:

- Creates a new workspace if one was not specified.
- Reports the workspace in the logging output so you know where you're running
- Alters the semantics if a workspace IS specified to create it if it doesn't already exist.
