### PR TITLE
fix: Duplicated logging output

### DIFF
--- a/src/steamship/utils/repl.py
+++ b/src/steamship/utils/repl.py
@@ -213,7 +213,7 @@ class AgentREPL(SteamshipREPL):
 class HttpREPL(SteamshipREPL):
     """REPL that uses an HTTP endpoint. Best for the `ship serve` command."""
 
-    prompt_url: Optional[AgentService]
+    prompt_url: Optional[str]
     client = Steamship
     config = None
     context_id: Optional[str] = None
@@ -280,11 +280,11 @@ class HttpREPL(SteamshipREPL):
                         logging.warning(
                             "REPL interaction completed with empty data field in InvocableResponse."
                         )
-                if isinstance(result, list):
+                elif isinstance(result, list):
                     self.print_object_or_objects(result)
                 else:
                     logging.warning("Unsure how to display result:")
-                    logging.warning(result)
+                    logging.warning(f"{result}")
             else:
                 logging.warning("REPL interaction completed with no result to print.")
 


### PR DESCRIPTION
The development REPL had an `if` instead of an `elif` causing duplicated output in some cases.