### PR TITLE
docs: add notice about ngrok acc

### DIFF
--- a/docs/nextra/developing/running.rst
+++ b/docs/nextra/developing/running.rst
@@ -1,3 +1,7 @@
+import { Callout } from \'nextra/components\';
+
+::
+
 Running on Localhost
 --------------------
 
@@ -6,6 +10,10 @@ To run your project on localhost type:
 .. code-block:: bash
 
    ship run local
+
+<Callout emoji=\"⚠️\">
+An ngrok account is required to run this command.
+</Callout>
 
 This will start a local instance with a number of ways to interact with it:
 

--- a/docs/nextra/index.rst
+++ b/docs/nextra/index.rst
@@ -1,3 +1,5 @@
+import { Callout } from \'nextra/components\';
+
 Steamship
 =========
 
@@ -38,6 +40,10 @@ Then run:
 .. code-block:: bash
 
    ship run local
+
+<Callout emoji=\"⚠️\">
+An ngrok account is required to run this command.
+</Callout>
 
 Now that you've interacted with your new agent, you're ready to start modifying it in :code:`src/api.py`.
 

--- a/docs/nextra/make_markdown.sh
+++ b/docs/nextra/make_markdown.sh
@@ -80,3 +80,9 @@ find "$DOCSDIR" -name '*.md' -exec sed -i '' 's/(\([^)]*.png\))/(\/\1)/g' {} \;
 
 # Remove the /index.md from all links
 find "$DOCSDIR" -name "*.md" -exec sed -i '' 's|/index.md||g' {} \;
+
+mdx=("$DOCSDIR/index.md" "$DOCSDIR/developing/running.md")
+# Convert all files in mdx to .mdx files
+for file in "${mdx[@]}"; do
+    mv "$file" "${file%.md}.mdx"
+done


### PR DESCRIPTION
Adds a disclaimer that an ngrok acc is required for running `ship run local`