### PR TITLE
CLI command for quickly deleting local development instances

### DIFF
--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -766,7 +766,8 @@ def support_info():
     default=False,
     help="Delete all local development instances without prompting",
 )
-def clean_local_dev_instances(all: Optional[bool] = False):
+@click.argument("environment", required=True, type=click.Choice(["local"], case_sensitive=False))
+def clean(environment: str, all: Optional[bool] = False):
     client, _, manifest = initialize_and_get_client_and_prep_project()
 
     if manifest.type != DeployableType.PACKAGE:
@@ -806,4 +807,4 @@ cli.add_command(run)
 cli.add_command(create_instance, name="use")
 cli.add_command(delete)
 cli.add_command(support_info, name="support-info")
-cli.add_command(clean_local_dev_instances, name="clean-local-dev")
+cli.add_command(clean)

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -766,7 +766,7 @@ def support_info():
     default=False,
     help="Delete all local development instances without prompting",
 )
-def delete_local_dev_instances(all: Optional[bool] = False):
+def clean_local_dev_instances(all: Optional[bool] = False):
     client, _, manifest = initialize_and_get_client_and_prep_project()
 
     if manifest.type != DeployableType.PACKAGE:
@@ -786,7 +786,7 @@ def delete_local_dev_instances(all: Optional[bool] = False):
         ):
             workspace = Workspace.get(client, instance.workspace_id)
             result = all or click.confirm(
-                f"Delete instance [{instance.handle}] in workspace [{workspace.handle}] created {instance.created_at}"
+                f"Delete instance [{instance.handle}] in workspace [{workspace.handle}] created {instance.created_at} ?"
             )
             if result:
                 instance.delete()
@@ -806,4 +806,4 @@ cli.add_command(run)
 cli.add_command(create_instance, name="use")
 cli.add_command(delete)
 cli.add_command(support_info, name="support-info")
-cli.add_command(delete_local_dev_instances, name="clean-local-dev")
+cli.add_command(clean_local_dev_instances, name="clean-local-dev")

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -32,6 +32,7 @@ from steamship.cli.requirements_init_wizard import requirements_init_wizard
 from steamship.cli.ship_spinner import ship_spinner
 from steamship.cli.utils import find_api_py, get_api_module
 from steamship.data.manifest import DeployableType, Manifest
+from steamship.data.package.package_instance import LOCAL_DEVELOPMENT_VERSION_HANDLE
 from steamship.data.user import User
 from steamship.invocable.dev_logging_handler import DevelopmentLoggingHandler
 from steamship.invocable.lambda_handler import get_class_from_module
@@ -758,6 +759,43 @@ def support_info():
     click.secho(f"In virtual env: {sys.prefix != sys.base_prefix}")
 
 
+@click.command()
+@click.option(
+    "--all",
+    is_flag=True,
+    default=False,
+    help="Delete all local development instances without prompting",
+)
+def delete_local_dev_instances(all: Optional[bool] = False):
+    client, _, manifest = initialize_and_get_client_and_prep_project()
+
+    if manifest.type != DeployableType.PACKAGE:
+        click.secho("May only delete development instances of Packages.", fg="red")
+        return
+
+    click.secho(
+        f"Deleting LOCAL DEVELOPMENT instances of package [{manifest.handle}] across workspaces."
+    )
+    for instance in PackageInstance.list(
+        client, include_workspace=True, across_workspaces=True
+    ).package_instances:
+        # Only consider deletion for LOCAL DEVELOPMENT instances of THIS PACKAGE.
+        if (
+            instance.package_version_handle == LOCAL_DEVELOPMENT_VERSION_HANDLE
+            and instance.package_handle == manifest.handle
+        ):
+            workspace = Workspace.get(client, instance.workspace_id)
+            result = all or click.confirm(
+                f"Delete instance [{instance.handle}] in workspace [{workspace.handle}] created {instance.created_at}"
+            )
+            if result:
+                instance.delete()
+                click.secho(
+                    f"Deleted instance [{instance.handle}] in workspace [{workspace.handle}]",
+                    fg="red",
+                )
+
+
 cli.add_command(login)
 cli.add_command(deploy)
 cli.add_command(info)
@@ -768,3 +806,4 @@ cli.add_command(run)
 cli.add_command(create_instance, name="use")
 cli.add_command(delete)
 cli.add_command(support_info, name="support-info")
+cli.add_command(delete_local_dev_instances, name="clean-local-dev")

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -790,11 +790,17 @@ def clean(environment: str, all: Optional[bool] = False):
                 f"Delete instance [{instance.handle}] in workspace [{workspace.handle}] created {instance.created_at} ?"
             )
             if result:
-                instance.delete()
-                click.secho(
-                    f"Deleted instance [{instance.handle}] in workspace [{workspace.handle}]",
-                    fg="red",
-                )
+                try:
+                    instance.delete()
+                    click.secho(
+                        f"Deleted instance [{instance.handle}] in workspace [{workspace.handle}]",
+                        fg="red",
+                    )
+                except Exception as e:
+                    click.secho(
+                        f"Could NOT delete instance [{instance.handle}] in workspace [{workspace.handle}].  Error: {str(e)}",
+                        fg="red",
+                    )
 
 
 cli.add_command(login)

--- a/tests/steamship_tests/app/integration/test_package_instance.py
+++ b/tests/steamship_tests/app/integration/test_package_instance.py
@@ -301,3 +301,12 @@ def test_package_spec_sdk_version():
     test_package = TestPackage()
     spec = test_package.__steamship_dir__()
     assert spec["sdkVersion"] is not None
+
+
+@pytest.mark.usefixtures("client")
+def test_list(client: Steamship):
+    demo_package_path = PACKAGES_PATH / "demo_package.py"
+    with deploy_package(client, demo_package_path) as (_, _, instance):
+        list_result = PackageInstance.list(client).package_instances
+        assert len(list_result) == 1
+        assert list_result[0].id == instance.id


### PR DESCRIPTION
Per discussion on discord: https://discord.com/channels/927675537390968882/927675537390968885/1159144491450630224

Create a command `clean local` which iterates through local development instances of the current package, across workspaces, and asks the user if they wish to delete.  Using the `--all` flag deletes them without prompt.

```
$ ship clean local
Steamship Python CLI version 2.17.31.post1.dev0+g47b0eb17.d20231004
Deleting LOCAL DEVELOPMENT instances of package [my-test-package] across workspaces.
Delete instance [urbane-firefly-rjlch] in workspace [teal-moon-yyeue] created 2023-10-04 20:14:26+00:00 [y/N]: y
Deleted instance [urbane-firefly-rjlch] in workspace [teal-moon-yyeue]
Delete instance [light-shelter-gdgph] in workspace [default] created 2023-10-04 17:42:38+00:00 [y/N]:
```

```
ship clean local --all
Steamship Python CLI version 2.17.31.post1.dev0+g47b0eb17.d20231004
Deleting LOCAL DEVELOPMENT instances of package [my-test-package] across workspaces.
Deleted instance [light-shelter-gdgph] in workspace [default]
```