### PR TITLE
docs fix: logo doesn't exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="docs/_static/Steamship-symbol-dark.png" alt="Steamship Logo" width="100"/>
+<img src="https://python-sdk.docs.steamship.com/_static/Steamship-symbol-light.png" alt="Steamship Logo" width="100"/>
 
 # Steamship Python SDK
 


### PR DESCRIPTION
Logo of readme.md doesn't exists:
![image](https://github.com/steamship-core/python-client/assets/79672134/e02f19c9-1095-4d61-a52c-83cf56cae0da)

I fixed this, referencing for [Docs SteamShip](https://python-sdk.docs.steamship.com/):
![image](https://github.com/steamship-core/python-client/assets/79672134/3acc90e7-bbe7-422b-8de5-e7df991ffeec)
