### PR TITLE
Warn against unsupported Python version when running CLI

### DIFF
--- a/src/steamship/__init__.py
+++ b/src/steamship/__init__.py
@@ -34,21 +34,17 @@ from .data import (
 
 from .client import Steamship  # isort:skip
 
-# None acts as wildcard here.  Major version number is always assumed to be non-None.
-SUPPORTED_PYTHON_VERSIONS = [(3, 10, None)]
+SUPPORTED_PYTHON_VERSIONS = [(3, 10)]
+SUPPORTED_PYTHON_VERSION_NAMES = [f"{major}.{minor}" for major, minor in SUPPORTED_PYTHON_VERSIONS]
 
 
 def is_supported_python_version() -> bool:
     import sys
 
-    major, minor, patch, _, _ = sys.version_info
+    major, minor, _, _, _ = sys.version_info
     for supported_version in SUPPORTED_PYTHON_VERSIONS:
-        s_major, s_minor, s_patch = supported_version
-        supported = (
-            (major == s_major)
-            and (s_minor is None or s_minor == minor)
-            and (s_patch is None or s_patch == patch)
-        )
+        s_major, s_minor = supported_version
+        supported = (major == s_major) and (s_minor is None or s_minor == minor)
         if supported:
             break
     else:

--- a/src/steamship/__init__.py
+++ b/src/steamship/__init__.py
@@ -41,7 +41,7 @@ SUPPORTED_PYTHON_VERSIONS = [(3, 10, None)]
 def is_supported_python_version() -> bool:
     import sys
 
-    major, minor, patch = sys.version_info
+    major, minor, patch, _, _ = sys.version_info
     for supported_version in SUPPORTED_PYTHON_VERSIONS:
         s_major, s_minor, s_patch = supported_version
         supported = (

--- a/src/steamship/__init__.py
+++ b/src/steamship/__init__.py
@@ -34,6 +34,28 @@ from .data import (
 
 from .client import Steamship  # isort:skip
 
+# None acts as wildcard here.  Major version number is always assumed to be non-None.
+SUPPORTED_PYTHON_VERSIONS = [(3, 10, None)]
+
+
+def is_supported_python_version() -> bool:
+    import sys
+
+    major, minor, patch = sys.version_info
+    for supported_version in SUPPORTED_PYTHON_VERSIONS:
+        s_major, s_minor, s_patch = supported_version
+        supported = (
+            (major == s_major)
+            and (s_minor is None or s_minor == minor)
+            and (s_patch is None or s_patch == patch)
+        )
+        if supported:
+            break
+    else:
+        return False
+    return True
+
+
 __all__ = [
     "Steamship",
     "Configuration",

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -40,7 +40,7 @@ from steamship.utils.repl import HttpREPL
 
 @click.group()
 def cli():
-    if not (sys.version_info[0] == 3 and sys.version_info[1] == 10):
+    if not steamship.is_supported_python_version():
         click.echo(f"⚠️⚠️ Running on unsupported Python version: {sys.version}")
         click.echo("⚠️⚠️ Steamship runtime supports Python 3.10.X; you may see irregular behavior.")
         click.echo("⚠️⚠️ Please develop against supported Python versions.")

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -40,7 +40,10 @@ from steamship.utils.repl import HttpREPL
 
 @click.group()
 def cli():
-    pass
+    if not (sys.version_info[0] == 3 and sys.version_info[1] == 10):
+        click.echo(f"⚠️⚠️ Running on unsupported Python version: {sys.version}")
+        click.echo("⚠️⚠️ Steamship runtime supports Python 3.10.X; you may see irregular behavior.")
+        click.echo("⚠️⚠️ Please develop against supported Python versions.")
 
 
 def initialize(suppress_message: bool = False):

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -43,7 +43,11 @@ def cli():
     if not steamship.is_supported_python_version():
         click.echo("⚠️ ⚠️ ⚠️️️️️️️️️️️")
         click.echo(f"Running on unsupported Python version: {sys.version}")
-        click.echo("Steamship runtime supports Python 3.10.X; you may see irregular behavior.")
+        click.echo(
+            "Steamship runtime supports only the following versions; you may see irregular behavior otherwise:"
+        )
+        for supported_name in steamship.SUPPORTED_PYTHON_VERSION_NAMES:
+            click.echo(f"  {supported_name}")
         click.echo("Please develop against supported Python versions.")
         click.echo("⚠️ ⚠️ ⚠️️️️️️️️️️️")
 

--- a/src/steamship/cli/cli.py
+++ b/src/steamship/cli/cli.py
@@ -41,9 +41,11 @@ from steamship.utils.repl import HttpREPL
 @click.group()
 def cli():
     if not steamship.is_supported_python_version():
-        click.echo(f"⚠️⚠️ Running on unsupported Python version: {sys.version}")
-        click.echo("⚠️⚠️ Steamship runtime supports Python 3.10.X; you may see irregular behavior.")
-        click.echo("⚠️⚠️ Please develop against supported Python versions.")
+        click.echo("⚠️ ⚠️ ⚠️️️️️️️️️️️")
+        click.echo(f"Running on unsupported Python version: {sys.version}")
+        click.echo("Steamship runtime supports Python 3.10.X; you may see irregular behavior.")
+        click.echo("Please develop against supported Python versions.")
+        click.echo("⚠️ ⚠️ ⚠️️️️️️️️️️️")
 
 
 def initialize(suppress_message: bool = False):


### PR DESCRIPTION
During the initialization of the CLI, check the Python version and warn if it's not supported.

I took this approach to attempt to be nice, rather than immediately explode in the SDK itself, though the SDK could certainly leverage the `__init__.py` code here.

-------------

When running on 3.8:

<img width="692" alt="Screenshot 2023-10-05 at 11 10 45 PM" src="https://github.com/steamship-core/python-client/assets/5051941/6c4cb094-594f-4e25-a87b-9dec1d01086e">


When running on 3.11:

<img width="812" alt="Screenshot 2023-10-05 at 11 10 59 PM" src="https://github.com/steamship-core/python-client/assets/5051941/c8ec7737-3070-4278-8542-4ba84db055db">


When running on 3.10:

<img width="406" alt="Screenshot 2023-10-05 at 11 14 09 PM" src="https://github.com/steamship-core/python-client/assets/5051941/64405c7a-db31-45b8-add8-928e71577b76">
