### PR TITLE
Roll back secrets change

### DIFF
--- a/src/steamship/invocable/invocable.py
+++ b/src/steamship/invocable/invocable.py
@@ -180,7 +180,7 @@ class Invocable(ABC):
         # creation. All subsequent method invocations reuse that frozen config.
         config = {
             **secret_kwargs,
-            **{k: v for k, v in (config or {}).items()},
+            **{k: v for k, v in (config or {}).items() if v != ""},
         }
 
         # Finally, we set the config object to an instance of the class returned by `self.config_cls`


### PR DESCRIPTION
Reverts "Invocable initialization should not remove config values that are empty strings (#593)"

This reverts commit 0c19da1246b5de72f8890d48fb008172aa81457e.